### PR TITLE
A possible fix to reference breadcrumb

### DIFF
--- a/breadcrumb/toc.yml
+++ b/breadcrumb/toc.yml
@@ -3,7 +3,7 @@
   topicHref: /azure/index
   items:
   - name: Azure libraries for .NET
-    tocHref: /dotnet
+    tocHref: /dotnet/
     topicHref: /dotnet/azure/index
     items:
     - name: Install


### PR DESCRIPTION
This is not ideal, but given that azure conceptual and reference topics does not share a unique url base path (due to base path merge), this is a workable solution.

Example:
https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/appservice?view=azure-dotnet&branch=breadcrumbTest