### PR TITLE
Corrected service name on landing page nav

### DIFF
--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -81,15 +81,15 @@
       landingPageType: Service
       children:
       - 'Microsoft.Azure.Documents*'
-  - name: Data Factories
-    uid: azure.net.sdk.landingPage.services.DataFactories
+  - name: Data Factory
+    uid: azure.net.sdk.landingPage.services.DataFactory
     href: ~/api/overview/azure/data-factory.md
     items:
     - name: Management
-      uid: azure.net.sdk.landingPage.services.DataFactories.Management
+      uid: azure.net.sdk.landingPage.services.DataFactory.Management
       landingPageType: Service
       children:
-      - 'Microsoft.Azure.Management.DataFactories*'
+      - 'Microsoft.Azure.Management.DataFactory*'
   - name: Data Lake Analytics
     uid: azure.net.sdk.landingPage.services.DataLakeAnalytics
     href: ~/api/overview/azure/data-lake-analytics.md


### PR DESCRIPTION
@CamSoper - Not sure if you're the one to ping for this issue
Please check instances of "Data Factory" on TOC.
* Is currently: Data Factories
* Should be: Data Factory
I understand changing IDs may break things -- please ensure service name is spelled correctly throughout.