### PR TITLE
Assign IoT SDK to correct service

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -103,7 +103,7 @@
         "api/Microsoft.Azure.Management.Datafactories*.yml": "data-factory",
         "api/Microsoft.Azure.Management.DataLake.analytics*.yml": "data-lake-analytics",
         "api/Microsoft.Azure.Management.DataLake.Store*.yml": "data-lake-store",
-        "api/Microsoft.Azure.Devices*.yml": "iot-suite",
+        "api/Microsoft.Azure.Devices*.yml": "iot-hub",
         "api/Microsoft.Azure.Management.Dns*.yml": "dns",
         "api/Microsoft.Azure.Management.EventHub*.yml": "event-hubs",
         "api/Microsoft.Azure.EventHubs*.yml": "event-hubs",


### PR DESCRIPTION
The Azure IoT SDK ref docs are currently assigned to the **iot-suite** service. they should be assigned to the **iot-hub** service.