### PR TITLE
Missing ; in code

### DIFF
--- a/api/overview/azure/resource-manager.md
+++ b/api/overview/azure/resource-manager.md
@@ -42,7 +42,7 @@ This example creates a new resource group.
 
 ```csharp
 /* Include these "using" directives.
-using Microsoft.Azure.Management.ResourceManager.Fluent
+using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 */
 


### PR DESCRIPTION
There is a missing ';' in a code sample for the page resource-manager