### PR TITLE
Update the URL for "Explore the management APIs"

### DIFF
--- a/api/overview/azure/virtualmachines.md
+++ b/api/overview/azure/virtualmachines.md
@@ -65,7 +65,7 @@ IVirtualMachine windowsVM = azure.VirtualMachines.Define("MyVirtualMachine")
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the management APIs](https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/virtualmachines/management?view=azure-dotnet)
+> [Explore the management APIs](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/virtualmachines/management?view=azure-dotnet)
 
 ### Samples
 


### PR DESCRIPTION
The current URL returns a 503-Forbidden, since it points to the 'review' subdomain. Deleting the subdomain from the URL loads the documents properly.