### PR TITLE
Update FabricClient.xml to fix circular reference

### DIFF
--- a/xml/System.Fabric/FabricClient.xml
+++ b/xml/System.Fabric/FabricClient.xml
@@ -601,10 +601,10 @@
       </ReturnValue>
       <Docs>
         <summary>
-          <para>Gets the <see cref="P:System.Fabric.FabricClient.PropertyManager" /> that can be used to perform operations related to names and properties.</para>
+          <para>Gets the <see cref="P:System.Fabric.FabricClient.PropertyManagementClient" /> that can be used to perform operations related to names and properties.</para>
         </summary>
         <value>
-          <para>The <see cref="P:System.Fabric.FabricClient.PropertyManager" /> that can be used to perform operations related to names and properties.</para>
+          <para>The <see cref="P:System.Fabric.FabricClient.PropertyManagementClient" /> that can be used to perform operations related to names and properties.</para>
         </value>
         <remarks>To be added.</remarks>
       </Docs>


### PR DESCRIPTION
Currently [this page](https://docs.microsoft.com/pt-br/dotnet/api/system.fabric.fabricclient.propertymanager?view=azure-dotnet) has a circular reference back to itself if you try to click on "PropertyManager" in the property description. I think this should be pointing to the [PropertyManagementClient](https://docs.microsoft.com/en-us/dotnet/api/system.fabric.fabricclient.propertymanagementclient?view=azure-dotnet) class based off of the type that this method returns.