### PR TITLE
GetBodyStream can only return underlying stream.

### DIFF
--- a/xml/Microsoft.ServiceBus.Messaging/EventData.xml
+++ b/xml/Microsoft.ServiceBus.Messaging/EventData.xml
@@ -205,7 +205,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Gets or sets the underlying stream to the event data body.</summary>
+        <summary>Gets the underlying stream to the event data body.</summary>
         <returns>The underlying stream to the event data body.</returns>
         <remarks>This method can only be called once and afterwards method will throw <see cref="T:System.InvalidOperationException" />.</remarks>
       </Docs>


### PR DESCRIPTION
Current code (from Microsoft.ServiceBus.dll, from WindowsAzure.ServiceBus.4.1.3 nuget package) is:
```
    public Stream GetBodyStream()
    {
      this.ThrowIfDisposed();
      this.SetGetBodyCalled();
      if (this.bodyStream != null)
        return this.bodyStream;
      return Stream.Null;
    }
```