### PR TITLE
Fixing "Next steps" CTA

### DIFF
--- a/docs-ref-conceptual/dotnet-howto-migrate-app-service.md
+++ b/docs-ref-conceptual/dotnet-howto-migrate-app-service.md
@@ -53,4 +53,4 @@ If your application persists data, you will need to update it to use Azure Stora
 ## Next steps
 
 > [!div class="nextstepaction"]
-> [Migrate an ASP.NET Web application to an Azure Virtual Machine](dotnet-howto-migrate-to-vm.md)
+> [Migrate an ASP.NET Web application to Azure App Service](https://aka.ms/azure-webapp-migrate)


### PR DESCRIPTION
Fixing link at the bottom of the tutorial to point to the Web Apps tutorial rather than the VM tutorial