### PR TITLE
C5697: Incorrect format for links on the buttom of the article

### DIFF
--- a/api/overview/azure/postgresql.md
+++ b/api/overview/azure/postgresql.md
@@ -70,6 +70,8 @@ using (NpgsqlConnection conn = new NpgsqlConnection(connectionString))
 ### Samples
 
 - [ADO.NET code examples](/dotnet/framework/data/adonet/ado-net-code-examples)
-- [Design a PostgreSQL database using the Azure CLI](https://docs.microsoft.com/azure/postgresql/tutorial-design-database-using-azure-cli) 
+- [Design a PostgreSQL database using the Azure CLI](https://docs.microsoft.com/azure/postgresql/tutorial-design-database-using-azure-cli)
+
+
 [PackageManager]: https://docs.microsoft.com/nuget/tools/package-manager-console
 [DotNetCLI]: https://docs.microsoft.com/dotnet/core/tools/dotnet-add-package


### PR DESCRIPTION
Hello, @CamSoper,
Localization team has reported source content issue that cause localized version to have broken format compared to en-us version.  The links at the buttom of the article are displayed incorrectly. 

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR, or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.