### PR TITLE
Fix documentation link for OfferType

### DIFF
--- a/xml/Microsoft.Azure.Documents.Client/RequestOptions.xml
+++ b/xml/Microsoft.Azure.Documents.Client/RequestOptions.xml
@@ -717,7 +717,7 @@
         <remarks>
             This option is only valid when creating a document collection.
             <para>
-            Refer to http://azure.microsoft.comdocumentation/articles/documentdb-performance-levels/ for the list of valid
+            Refer to http://azure.microsoft.com/documentation/articles/documentdb-performance-levels/ for the list of valid
             offer types.
             </para></remarks>
         <example>


### PR DESCRIPTION
Documentation link had a typo in it.