### PR TITLE
Removed duplicated examples

### DIFF
--- a/xml/Microsoft.Azure.Documents.Client/ConnectionPolicy.xml
+++ b/xml/Microsoft.Azure.Documents.Client/ConnectionPolicy.xml
@@ -374,34 +374,6 @@
             
              DocumentClient client = new DocumentClient(new Uri("service endpoint"), "auth key", connectionPolicy);
              ]]></code></example>
-        <example>
-             The example below creates a new <see cref="T:Microsoft.Azure.Documents.Client.DocumentClient" /> and sets the <see cref="T:Microsoft.Azure.Documents.Client.ConnectionPolicy" /> 
-             using the <see cref="P:Microsoft.Azure.Documents.Client.ConnectionPolicy.RetryOptions" /> property. 
-             <para><see cref="P:Microsoft.Azure.Documents.Client.RetryOptions.MaxRetryAttemptsOnThrottledRequests" /> is set to 3, so in this case, if a request operation is rate limited by exceeding the reserved 
-             throughput for the collection, the request operation retries 3 times before throwing the exception to the application.
-             <see cref="P:Microsoft.Azure.Documents.Client.RetryOptions.MaxRetryWaitTimeInSeconds" /> is set to 60, so in this case if the cumulative retry 
-             wait time in seconds since the first request exceeds 60 seconds, the exception is thrown.
-             </para><code language="c#"><![CDATA[
-             ConnectionPolicy connectionPolicy = new ConnectionPolicy();
-             connectionPolicy.RetryOptions.MaxRetryAttemptsOnThrottledRequests = 3;
-             connectionPolicy.RetryOptions.MaxRetryWaitTimeInSeconds = 60;
-            
-             DocumentClient client = new DocumentClient(new Uri("service endpoint"), "auth key", connectionPolicy);
-             ]]></code></example>
-        <example>
-             The example below creates a new <see cref="T:Microsoft.Azure.Documents.Client.DocumentClient" /> and sets the <see cref="T:Microsoft.Azure.Documents.Client.ConnectionPolicy" /> 
-             using the <see cref="P:Microsoft.Azure.Documents.Client.ConnectionPolicy.RetryOptions" /> property. 
-             <para><see cref="P:Microsoft.Azure.Documents.Client.RetryOptions.MaxRetryAttemptsOnThrottledRequests" /> is set to 3, so in this case, if a request operation is rate limited by exceeding the reserved 
-             throughput for the collection, the request operation retries 3 times before throwing the exception to the application.
-             <see cref="P:Microsoft.Azure.Documents.Client.RetryOptions.MaxRetryWaitTimeInSeconds" /> is set to 60, so in this case if the cumulative retry 
-             wait time in seconds since the first request exceeds 60 seconds, the exception is thrown.
-             </para><code language="c#"><![CDATA[
-             ConnectionPolicy connectionPolicy = new ConnectionPolicy();
-             connectionPolicy.RetryOptions.MaxRetryAttemptsOnThrottledRequests = 3;
-             connectionPolicy.RetryOptions.MaxRetryWaitTimeInSeconds = 60;
-            
-             DocumentClient client = new DocumentClient(new Uri("service endpoint"), "auth key", connectionPolicy);
-             ]]></code></example>
       </Docs>
     </Member>
     <Member MemberName="UserAgentSuffix">


### PR DESCRIPTION
All of three examples are the same (https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.connectionpolicy.retryoptions?view=azure-dotnet#Microsoft_Azure_Documents_Client_ConnectionPolicy_RetryOptions)