### PR TITLE
Added comment on property name with '_' (underscore).

### DIFF
--- a/xml/Microsoft.WindowsAzure.Storage.Table/EntityPropertyConverter.xml
+++ b/xml/Microsoft.WindowsAzure.Storage.Table/EntityPropertyConverter.xml
@@ -134,7 +134,8 @@
         <summary>
             Traverses object graph, flattens and converts all nested (and not nested) properties to EntityProperties, stores them in the property dictionary.
             The keys are constructed by appending the names of the properties visited during pre-order depth first traversal from root to each end node property delimited by '_'.
-            Allows complex objects to be stored in persistent storage systems or passed between web services in a generic way.
+            Allows complex objects to be stored in persistent storage systems or passed between web services in a generic way. 
+            PS: Rename any existing property name, removing '_' (underscore).
             </summary>
         <returns>The result containing <see cref="T:System.Collections.Generic.IDictionary`2" /> of <see cref="T:Microsoft.WindowsAzure.Storage.Table.EntityProperty" /> objects for all properties of the flattened root object.</returns>
         <remarks>To be added.</remarks>
@@ -167,6 +168,7 @@
             Traverses object graph, flattens and converts all nested (and not nested) properties to EntityProperties, stores them in the property dictionary.
             The keys are constructed by appending the names of the properties visited during pre-order depth first traversal from root to each end node property delimited by '_'.
             Allows complex objects to be stored in persistent storage systems or passed between web services in a generic way.
+            PS: Rename any existing property name, removing '_' (underscore).
             </summary>
         <returns>The result containing <see cref="T:System.Collections.Generic.IDictionary`2" /> of <see cref="T:Microsoft.WindowsAzure.Storage.Table.EntityProperty" /> objects for all properties of the flattened root object.</returns>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
Runtime failure could be cryptic, added a comment to rename property name to exclude '_' (underscore).