### PR TITLE
Fixing toc for ADAL.NET and MSAL.NET ref doc

### DIFF
--- a/xml/_filter.xml
+++ b/xml/_filter.xml
@@ -10,6 +10,15 @@
     <namespaceFilter name="Microsoft.IdentityModel.Clients.ActiveDirectory.Exceptions">
       <typeFilter name="*" expose="false" />
     </namespaceFilter>
+    <namespaceFilter name="Microsoft.Identity.Client.Internal.UI">
+      <typeFilter name="*" expose="false" />
+    </namespaceFilter>
+    <namespaceFilter name="Microsoft.IdentityModel.Clients.ActiveDirectory.Internal">
+      <typeFilter name="*" expose="false" />
+    </namespaceFilter>
+    <namespaceFilter name="Microsoft.IdentityModel.Clients.ActiveDirectory.Native">
+      <typeFilter name="*" expose="false" />
+    </namespaceFilter>
     <namespaceFilter name="Owin">
       <typeFilter name="*" expose="false" />
     </namespaceFilter>


### PR DESCRIPTION
the toc of the reference documentation for ADAL.NET and MSAL.NET shows internal namespaces that should not be presented
![image](https://user-images.githubusercontent.com/13203188/45063123-34442e80-b061-11e8-879d-e3d5df5ffd60.png)

this PR aims at hiding them

cc: @dend 
