### PR TITLE
Typo

### DIFF
--- a/xml/Microsoft.IdentityModel.Clients.ActiveDirectory/UserIdentifier.xml
+++ b/xml/Microsoft.IdentityModel.Clients.ActiveDirectory/UserIdentifier.xml
@@ -60,7 +60,7 @@
       </ReturnValue>
       <Docs>
         <summary>
-            Gets an static instance of <see cref="T:Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" /> to represent any user.
+            Gets a static instance of <see cref="T:Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" /> to represent any user.
             </summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
GitHub web editor automatically also changes the newline at the end of the file. I didn't intend this change.