### PR TITLE
Fixed link not appearing as a link

### DIFF
--- a/xml/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectRequestType.xml
+++ b/xml/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectRequestType.xml
@@ -58,7 +58,7 @@
       <MemberValue>1</MemberValue>
       <Docs>
         <summary>
-            Indicates a Logout Request see:http://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout.
+            Indicates a Logout Request see: http://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout.
             </summary>
       </Docs>
     </Member>


### PR DESCRIPTION
Added a space to be consistent with the other enum member's summaries that render a clickable link.