### PR TITLE
Creating Uri object from URI string

### DIFF
--- a/xml/Microsoft.Azure.EventHubs/EventHubsConnectionStringBuilder.xml
+++ b/xml/Microsoft.Azure.EventHubs/EventHubsConnectionStringBuilder.xml
@@ -29,7 +29,7 @@
             Sample code:
             <code>
             var connectionStringBuiler = new EventHubsConnectionStringBuilder(
-                "amqps://EventHubsNamespaceName.servicebus.windows.net", 
+                new Uri("amqps://EventHubsNamespaceName.servicebus.windows.net"), 
                 "EventHubsEntityName", // Event Hub Name 
                 "SharedAccessSignatureKeyName", 
                 "SharedAccessSignatureKey");


### PR DESCRIPTION
Original code didn't compile. Compiler threw `Argument 1: cannot convert from 'string' to 'System.Uri'`.

Fixes #859 Code snippet does not compile