### PR TITLE
Added default timeout value to deviceclient.receiveasync()

### DIFF
--- a/xml/Microsoft.Azure.Devices.Client/DeviceClient.xml
+++ b/xml/Microsoft.Azure.Devices.Client/DeviceClient.xml
@@ -748,7 +748,7 @@
       <Parameters />
       <Docs>
         <summary>
-            Receive a message from the device queue using the default timeout.
+            Receive a message from the device queue using the default timeout. The default value is 4 minutes.
             </summary>
         <returns>The receive message or null if there was no message until the default timeout</returns>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
Clarified that the default timeout for `DeviceClient.ReceiveAsync()` value is 4 minutes.

This fixed #847 The default timeout should be documented.