### PR TITLE
Azure* is too aggressive, resulting in all Azure packages placed under Core service

### DIFF
--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -324,7 +324,8 @@
       uid: azure.net.sdk.landingPage.services.core.Client
       landingPageType: Service
       children:
-      - 'Azure*'
+      - 'Azure'
+      - 'Azure.ApplicationModel.Configuration'
       - 'Azure.Core*'
   - name: Cosmos DB
     uid: azure.net.sdk.landingPage.services.CosmosDB

--- a/xml/Microsoft.Azure.Management.Fluent/Azure+Configurable.xml
+++ b/xml/Microsoft.Azure.Management.Fluent/Azure+Configurable.xml
@@ -44,5 +44,31 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Microsoft.Azure.Management.Fluent.Azure+IConfigurable.Authenticate" ExplicitInterfaceMemberName="Microsoft.Azure.Management.Fluent.Azure.IConfigurable.Authenticate">
+      <MemberSignature Language="C#" Value="Microsoft.Azure.Management.Fluent.Azure.IAuthenticated Azure.IConfigurable.Authenticate (Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials credentials);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class Microsoft.Azure.Management.Fluent.Azure/IAuthenticated Microsoft.Azure.Management.Fluent.Azure.IConfigurable.Authenticate(class Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials credentials) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Microsoft.Azure.Management.Fluent.Azure.Configurable.Microsoft#Azure#Management#Fluent#Azure#IConfigurable#Authenticate(Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials)" />
+      <MemberSignature Language="VB.NET" Value="Function Authenticate (credentials As AzureCredentials) As Azure.IAuthenticated Implements Azure.IConfigurable.Authenticate" />
+      <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:Microsoft.Azure.Management.Fluent.Azure.IConfigurable.Authenticate(Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials)</InterfaceMember>
+      </Implements>
+      <AssemblyInfo>
+        <AssemblyName>Microsoft.Azure.Management.Fluent</AssemblyName>
+        <AssemblyVersion>1.0.0.61</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Azure.Management.Fluent.Azure+IAuthenticated</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="credentials" Type="Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials" />
+      </Parameters>
+      <Docs>
+        <param name="credentials">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/xml/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceManager+Configurable.xml
+++ b/xml/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceManager+Configurable.xml
@@ -44,5 +44,31 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager+IConfigurable.Authenticate" ExplicitInterfaceMemberName="Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager.IConfigurable.Authenticate">
+      <MemberSignature Language="C#" Value="Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager.IAuthenticated ResourceManager.IConfigurable.Authenticate (Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials credentials);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager/IAuthenticated Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager.IConfigurable.Authenticate(class Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials credentials) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager.Configurable.Microsoft#Azure#Management#ResourceManager#Fluent#ResourceManager#IConfigurable#Authenticate(Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials)" />
+      <MemberSignature Language="VB.NET" Value="Function Authenticate (credentials As AzureCredentials) As ResourceManager.IAuthenticated Implements ResourceManager.IConfigurable.Authenticate" />
+      <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager.IConfigurable.Authenticate(Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials)</InterfaceMember>
+      </Implements>
+      <AssemblyInfo>
+        <AssemblyName>Microsoft.Azure.Management.ResourceManager.Fluent</AssemblyName>
+        <AssemblyVersion>1.0.0.61</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager+IAuthenticated</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="credentials" Type="Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials" />
+      </Parameters>
+      <Docs>
+        <param name="credentials">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/xml/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.xml
+++ b/xml/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.xml
@@ -185,8 +185,8 @@
             and custom IHttpClientFactory.
             Make sure you are aware of the security implication of not validating the address.
             </summary>
-        <remarks>ADAL does not guarantee that it will not modify the HttpClient, for example by adding new headers.</remarks>
         <remarks>See https://aka.ms/adal-net-httpclient for details</remarks>
+        <remarks>ADAL does not guarantee that it will not modify the HttpClient, for example by adding new headers.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AcquireDeviceCodeAsync">

--- a/xml/Microsoft.ServiceBus.Messaging.Configuration/NetMessagingBindingExtensionElement.xml
+++ b/xml/Microsoft.ServiceBus.Messaging.Configuration/NetMessagingBindingExtensionElement.xml
@@ -180,6 +180,7 @@
             that contains a collection of <see cref="T:System.Configuration.ConfigurationProperty" />
             objects that can be attributes or <see cref="T:System.Configuration.ConfigurationElement" />
             objects of this configuration element. </summary>
+        <value> The properties. </value>
         <value> A <see cref="T:System.Configuration.ConfigurationPropertyCollection" /> instance
             that contains a collection of <see cref="T:System.Configuration.ConfigurationProperty" />
             objects that can be attributes or <see cref="T:System.Configuration.ConfigurationElement" />


### PR DESCRIPTION
Left `Azure` and `Azure.ApplicationModel.Configuration` under this service. The rest should start being placed in the correct location due to the prevention of the glob eating them.

Additional files here are due to the fact that I merged master into `smoke-test`, given that it was not fully up to date.