### PR TITLE
Azure* is too aggressive, resulting in all Azure packages placed under Core service

### DIFF
--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -324,7 +324,8 @@
       uid: azure.net.sdk.landingPage.services.core.Client
       landingPageType: Service
       children:
-      - 'Azure*'
+      - 'Azure'
+      - 'Azure.ApplicationModel.Configuration'
       - 'Azure.Core*'
   - name: Cosmos DB
     uid: azure.net.sdk.landingPage.services.CosmosDB


### PR DESCRIPTION
Left `Azure` and `Azure.ApplicationModel.Configuration` under this service. The rest should start being placed in the correct location due to the prevention of the glob eating them.

Additional files here are due to the fact that I merged master into `smoke-test`, given that it was not fully up to date.