### PR TITLE
[msid] switch ADAL to MSAL on AAD overview

### DIFF
--- a/api/overview/azure/activedirectory.md
+++ b/api/overview/azure/activedirectory.md
@@ -10,13 +10,13 @@ ms.service: active-directory
 
 ## Overview
 
-Sign in users and access protected web APIs with Azure Active Directory.
+Sign in users and access protected web APIs with Azure Active Directory (Azure AD).
 
 To get started developing applications with Azure Active Directory, see the [Microsoft identity platform](/azure/active-directory/develop/v2-overview).
 
 ## Client library
 
-Authenticate users and authorize access to web APIs using OpenID Connect and OAuth 2.0 with the Microsoft Authentication Library for .NET ([MSAL.NET](/azure/active-directory/develop/msal-net-initializing-client-applications)).
+Provide scoped access to web APIs protected by Azure AD using OpenID Connect and OAuth 2.0 with the Microsoft Authentication Library for .NET ([MSAL.NET](/azure/active-directory/develop/msal-net-initializing-client-applications)).
 
 Install the [NuGet package](https://www.nuget.org/packages/Microsoft.Identity.Client) directly from the Visual Studio [Package Manager console][PackageManager] or with the [.NET Core CLI][DotNetCLI].
 
@@ -34,16 +34,16 @@ dotnet add package Microsoft.Identity.Client
 
 ### Code example
 
-Retrieve an access token for the Microsoft Graph API in a desktop application.
+Retrieve an access token for the Microsoft Graph API in a desktop application (public client).
 
 ```csharp
 /* Include this using directive:
 using Microsoft.Identity.Client;
 */
 
-private static string ClientId = "11111111-1111-1111-1111-111111111111"; // Application (client) ID
-private static string Tenant = "common";
-private static string Instance = "https://login.microsoftonline.com/";
+string ClientId = "11111111-1111-1111-1111-111111111111"; // Application (client) ID
+string Tenant = "common";
+string Instance = "https://login.microsoftonline.com/";
 
 string graphAPIEndpoint = "https://graph.microsoft.com/v1.0/me";
 string[] scopes = new string[] { "user.read" };
@@ -52,7 +52,7 @@ AuthenticationResult authResult = null;
 
 var app = PublicClientApplicationBuilder.Create(ClientId)
                 .WithAuthority($"{Instance}{Tenant}")
-                .WithDefaultRedirectUri()
+                .WithRedirectUri("http://localhost")
                 .Build();
 
 var accounts = await app.GetAccountsAsync();

--- a/api/overview/azure/activedirectory.md
+++ b/api/overview/azure/activedirectory.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Active Directory libraries for .NET
 description: Reference for Azure Active Directory libraries for .NET
-ms.date: 10/19/2017
+ms.date: 07/24/2020
 ms.topic: reference
 ms.service: active-directory
 ---
@@ -10,50 +10,87 @@ ms.service: active-directory
 
 ## Overview
 
-Sign-on users and manage access to applications and APIs with Azure Active Directory.
+Sign in users and access protected web APIs with Azure Active Directory.
 
-To get started with Azure Active Directory, see [ASP.NET web app sign-in and sign-out with Azure AD](/azure/active-directory/develop/active-directory-devquickstarts-webapp-dotnet).
+To get started developing applications with Azure Active Directory, see the [Microsoft identity platform](/azure/active-directory/develop/v2-overview).
 
 ## Client library
 
-Connect and authenticate users or applications over OAuth2, OpenID Connect, Active Directory Graph API authentication or [SAML 2.0](https://docs.microsoft.com/azure/active-directory/develop/active-directory-saml-protocol-reference).
+Authenticate users and authorize access to web APIs using OpenID Connect and OAuth 2.0 with the Microsoft Authentication Library for .NET ([MSAL.NET](/azure/active-directory/develop/msal-net-initializing-client-applications)).
 
-Install the [NuGet package](https://www.nuget.org/packages/Microsoft.Azure.Management.AppService.Fluent) directly from the Visual Studio [Package Manager console][PackageManager] or with the [.NET Core CLI][DotNetCLI].
+Install the [NuGet package](https://www.nuget.org/packages/Microsoft.Identity.Client) directly from the Visual Studio [Package Manager console][PackageManager] or with the [.NET Core CLI][DotNetCLI].
 
 #### Visual Studio Package Manager
 
 ```powershell
-Install-Package Microsoft.IdentityModel.Clients.ActiveDirectory
+Install-Package Microsoft.Identity.Client
 ```
 
 #### .NET Core CLI
 
 ```dotnetcli
-dotnet add package Microsoft.IdentityModel.Clients.ActiveDirectory
+dotnet add package Microsoft.Identity.Client
 ```
 
-### Code Example
+### Code example
 
-Retrieve an access token for a desktop application.
+Retrieve an access token for the Microsoft Graph API in a desktop application.
 
 ```csharp
-/* Include this "using" directive...
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
+/* Include this using directive:
+using Microsoft.Identity.Client;
 */
 
-AuthenticationResult result = null;
-AuthenticationContext authContext = new AuthenticationContext("https://someauthority.com");
+private static string ClientId = "11111111-1111-1111-1111-111111111111"; // Application (client) ID
+private static string Tenant = "common";
+private static string Instance = "https://login.microsoftonline.com/";
+
+string graphAPIEndpoint = "https://graph.microsoft.com/v1.0/me";
+string[] scopes = new string[] { "user.read" };
+
+AuthenticationResult authResult = null;
+
+var app = PublicClientApplicationBuilder.Create(ClientId)
+                .WithAuthority($"{Instance}{Tenant}")
+                .WithDefaultRedirectUri()
+                .Build();
+
+var accounts = await app.GetAccountsAsync();
+var firstAccount = accounts.FirstOrDefault();
+
 try
 {
-    result = await authContext.AcquireTokenAsync(graphResourceId, clientId, redirectUri, new PlatformParameters(PromptBehavior.Auto));
+    // Always first try to acquire a token silently.
+    authResult = await app.AcquireTokenSilent(scopes, firstAccount)
+        .ExecuteAsync();
 }
-catch (AdalException ex)
+catch (MsalUiRequiredException ex)
 {
-    // An unexpected error occurred, or user canceled the sign in.
-    if (ex.ErrorCode != "access_denied")
-        MessageBox.Show(ex.Message);
+    // If an MsalUiRequiredException occurred when AcquireTokenSilent was called,
+    // it indicates you need to call AcquireTokenInteractive to acquire a token.
+    System.Diagnostics.Debug.WriteLine($"MsalUiRequiredException: {ex.Message}");
 
+    try
+    {
+        authResult = await app.AcquireTokenInteractive(scopes)
+            .WithAccount(firstAccount)
+            .WithPrompt(Prompt.SelectAccount)
+            .ExecuteAsync();
+    }
+    catch (MsalException msalex)
+    {
+        System.Diagnostics.Debug.WriteLine($"Error acquiring Token:{System.Environment.NewLine}{msalex}");
+    }
+}
+catch (Exception ex)
+{
+    System.Diagnostics.Debug.WriteLine($"Error acquiring token silently:{System.Environment.NewLine}{ex}");
     return;
+}
+
+if (authResult != null)
+{
+    System.Diagnostics.Debug.WriteLine($"Access token:{System.Environment.NewLine}{authResult.AccessToken}");
 }
 ```
 
@@ -62,11 +99,11 @@ catch (AdalException ex)
 
 ### Samples
 
-* [Use OpenID Connect to authenticate users from an Azure AD tenant](https://github.com/Azure-Samples/active-directory-dotnet-webapp-openidconnect)
-* [Use Oauth2 to call a web API with application permissions](https://github.com/Azure-Samples/active-directory-dotnet-webapp-webapi-oauth2-appidentity)
-* [Use role-based access control (RBAC) in an application](https://github.com/Azure-Samples/active-directory-dotnet-webapp-roleclaims)
+* [ASP.NET Core web app - sign in users](https://aka.ms/aspnetcore-webapp-sign-in)
+* [Windows desktop app (WPF) - sign in users](https://github.com/azure-samples/active-directory-dotnet-desktop-msgraph-v2)
+* [Use role-based access control (RBAC) in an application](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/tree/master/5-WebApp-AuthZ/5-1-Roles)
 
-Explore the full collection of [Azure Active Directory code samples](/azure/active-directory/develop/active-directory-code-samples).
+Explore the full collection of [Microsoft identity platform code samples](/azure/active-directory/develop/sample-v2-code).
 
 [PackageManager]: https://docs.microsoft.com/nuget/tools/package-manager-console
 [DotNetCLI]: https://docs.microsoft.com/dotnet/core/tools/dotnet-add-package


### PR DESCRIPTION
Interim update of the Azure AD client library overview to get away from ADAL (whose deprecation has been announced) over to MSAL.

Next update to this (not in this PR) would be to add Microsoft.Identity.Web once it goes GA, and also move to the new [Azure client library index](https://review.docs.microsoft.com/en-us/help/contribute-ref/template-library-index?branch=master) page format.