### PR TITLE
Adds note warning about setting content-type

### DIFF
--- a/api/overview/azure/ai.formrecognizer-readme-pre.md
+++ b/api/overview/azure/ai.formrecognizer-readme-pre.md
@@ -180,6 +180,11 @@ foreach (FormPage page in formPages)
 ### Recognize Custom Forms
 Recognize and extract form fields and other content from your custom forms, using models you train with your own form types.
 
+> [!NOTE] If you are uploading files to Azure Blob Storage progamatically before sending the URI to Form Recognizer, you will need to specify the Content-Type in the Blob Storage SDK like so 
+> `blobHttpHeaders.ContentType = "image/jpeg";` and `blobClient.SetHttpHeaders(blobHttpHeaders);`
+
+
+
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 


### PR DESCRIPTION
If you upload forms to evaluate in your custom models through the Blob Storage SDK and do not set a content-type, the Form Recognizer SDK will return an error when you pass it the URI of this file.  This edit warns users of this issue and shows how to set the content type.