### PR TITLE
Fix v3 Sample link and remove v2 examples

### DIFF
--- a/api/overview/azure/cosmosdb.md
+++ b/api/overview/azure/cosmosdb.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Cosmos DB libraries for .NET
 description: Reference for Azure Cosmos DB libraries for .NET
-ms.date: 06/18/2019
+ms.date: 03/05/2021
 ms.topic: reference
 ms.service: cosmos-db
 ---
@@ -20,20 +20,6 @@ Use the Azure Cosmos DB .NET client library to access and store data in an exist
 
 Install the [NuGet package](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) directly from the Visual Studio [Package Manager console][PackageManager] or with the [.NET Core CLI][DotNetCLI].
 
-To install version 2.x:
-
-#### Visual Studio Package Manager
-
-```powershell
-Install-Package Microsoft.Azure.DocumentDB.Core
-```
-
-#### .NET Core CLI
-
-```dotnetcli
-dotnet add package Microsoft.Azure.DocumentDB.Core
-```
-
 To install version 3.x, which targets .NET standard: 
 
 #### Visual Studio Package Manager
@@ -50,27 +36,15 @@ dotnet add package Microsoft.Azure.Cosmos
 
 ### Code Example
 
-This example connects to an existing Azure Cosmos DB SQL API database, reads a document from a collection, and deserializes it as an `TodoItem` object. This example uses version 2.x of the .NET SDK.   
-
-```csharp
-/* Include this "using" directive...
-using Microsoft.Azure.Documents.Client;
-*/
-
-DocumentClient client = new DocumentClient(endpointUri, authKeyString);
-Uri documentUri = UriFactory.CreateDocumentUri("MyDatabaseName", "MyCollectionName", "DocumentId");
-var todoItem = client.ReadDocumentAsync<TodoItem>(documentUri);
-```
-
 This example connects to an existing Azure Cosmos DB SQL API database, creates a new database and container, reads an item from the container, and deserializes it to a `TodoItem` object. This example uses version 3.x of the .NET SDK.   
 
 ```csharp
+// CosmosClient should always be a singleton for an application
 using (CosmosClient cosmosClient = new CosmosClient("endpoint", "primaryKey"))
 {
+    Container container = cosmosClient.GetContainer("DatabaseId", "ContainerId");
     // Read item from container
-    CosmosItemResponse<TodoItem> todoItemResponse = await cosmosClient
-                .GetContainer("DatabaseId", "ContainerId")
-                .ReadItemAsync<TodoItem>("ItemId", new PartitionKey("partitionKeyValue"));
+    CosmosItemResponse<TodoItem> todoItemResponse = await container.ReadItemAsync<TodoItem>("ItemId", new PartitionKey("partitionKeyValue"));
 }
 ```
 
@@ -83,7 +57,7 @@ using (CosmosClient cosmosClient = new CosmosClient("endpoint", "primaryKey"))
 
 * [.NET Core Console app using Azure Cosmos DB's SQL API](https://github.com/Azure-Samples/cosmos-dotnet-core-getting-started)
 
-* [Azure Cosmos DB .NET SDK samples](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/CodeSamples)
+* [Azure Cosmos DB .NET SDK samples](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/Usage)
 
 [PackageManager]: https://docs.microsoft.com/nuget/tools/package-manager-console
 [DotNetCLI]: https://docs.microsoft.com/dotnet/core/tools/dotnet-add-package


### PR DESCRIPTION
All new development should be done using the .NET v3 SDK. Removing reference to the v2 to avoid confusion. Fixed the sample link for the v3 SDK.