### PR TITLE
Update top_level_toc.yml to include Translation

### DIFF
--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -284,6 +284,11 @@
           href: ~/api/overview/azure/ai.textanalytics-readme.md
           children:
           - 'Azure.AI.TextAnalytics*'
+        - name: Translation
+          uid: azure.net.sdk.landingPage.services.CognitiveServices.Client.Translation
+          href: ~/api/overview/azure/ai.translation.document-readme-pre.md
+          children:
+          - 'Azure.AI.Translation.Document*'
         - name: QnA Maker 
           uid: azure.net.sdk.landingPage.services.CognitiveServices.Client.QnAMaker
           landingPageType: Service
@@ -1198,6 +1203,11 @@
       landingPageType: Service
       children:
       - 'Microsoft.Azure.Management.TrafficManager*'
+  - name: Translation
+    uid: azure.net.sdk.landingPage.services.Translation
+    href: ~/api/overview/azure/ai.translation.document-readme-pre.md
+    children:
+    - 'Azure.AI.Translation.Document*'
   - name: Virtual Machines
     uid: azure.net.sdk.landingPage.services.VirtualMachines
     href: ~/api/overview/azure/virtualmachines.md


### PR DESCRIPTION
I found the translation documentation in the `Other` section so I am hoping that with this change it will be removed from it.

![image](https://user-images.githubusercontent.com/9868623/115627487-f3ea5b00-a2b3-11eb-9ad3-4f523e0af4b9.png)
