### PR TITLE
Update data.tables readme, update ToC to point to GA

### DIFF
--- a/api/overview/azure/data.tables-readme-pre.md
+++ b/api/overview/azure/data.tables-readme-pre.md
@@ -13,9 +13,11 @@ ms.service: tables
 
 # Azure Tables client library for .NET - Version 12.2.0-beta.1 
 
+> [!IMPORTANT]
+> A non-preview version of the package is released. See [documentation here](data.tables-readme.md)
 
 Azure Table storage is a service that stores large amounts of structured NoSQL data in the cloud, providing 
-a key/attribute store with a schema-less design. 
+a key/attribute store with a schema-less design.
 
 Azure Cosmos DB provides a Table API for applications that are written for Azure Table storage that need premium capabilities like:
 

--- a/api/overview/azure/data.tables-readme-pre.md
+++ b/api/overview/azure/data.tables-readme-pre.md
@@ -14,7 +14,7 @@ ms.service: tables
 # Azure Tables client library for .NET - Version 12.2.0-beta.1 
 
 > [!IMPORTANT]
-> A non-preview version of the package is released. See [documentation here](data.tables-readme.md)
+> The Azure Tables client library for .NET is now generally available (GA) and fully supported for production use. More details on the GA release can be found in the [GA documentation](data.tables-readme.md)
 
 Azure Table storage is a service that stores large amounts of structured NoSQL data in the cloud, providing 
 a key/attribute store with a schema-less design.

--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -1206,7 +1206,7 @@
       - 'Azure.Analytics.Synapse.AccessControl*'
   - name: Tables
     uid: azure.net.sdk.landingPage.services.Tables
-    href:  ~/api/overview/azure/data.tables-readme-pre.md
+    href:  ~/api/overview/azure/data.tables-readme.md
     children:
       - 'Azure.Data.Tables*'
   - name: Text Analytics


### PR DESCRIPTION
* The ToC now uses the GA version of the service overview: https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/data.tables-readme?view=azure-dotnet&branch=djurek%2Ftables-navigation
* The preview text is not linked from the ToC but if the URL is visited again the content is updated with new text describing GA support: https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/data.tables-readme-pre?view=azure-dotnet&branch=djurek%2Ftables-navigation