### PR TITLE
Add note on explicit enablement of InteractiveBrowserCredential as pa…

### DIFF
--- a/xml/Azure.Identity/DefaultAzureCredential.xml
+++ b/xml/Azure.Identity/DefaultAzureCredential.xml
@@ -27,7 +27,8 @@
                <item><description><see cref="T:Azure.Identity.VisualStudioCodeCredential" /></description></item>
                <item><description><see cref="T:Azure.Identity.AzureCliCredential" /></description></item>
                <item><description><see cref="T:Azure.Identity.AzurePowerShellCredential" /></description></item>
-               <item><description><see cref="T:Azure.Identity.InteractiveBrowserCredential" /> (if explicitly enabled -- see Remarks section)</description></item></list>
+               <item><description><see cref="T:Azure.Identity.InteractiveBrowserCredential" /> (if explicitly enabled -- see Remarks section)</description></item>
+             </list>
              Consult the documentation of these credential types for more information on how they attempt authentication.
              </summary>
     <remarks>


### PR DESCRIPTION
…rt of DefaultAzureCredential.

Resolves https://github.com/Azure/azure-sdk-for-net/issues/24879.

At issue -- it is not clear by default that the list of credentials that are tried as part of `DefaultAzureCredential` doesn't actually include `InteractiveBrowserCredential` unless someone happens to scroll through to the remarks section of the document. 

Adding this text avoids the possibility that someone will be hit with this "gotcha" in their development, and will point them to the appropriate remarks.