### PR TITLE
One stop mass update for author and ms.author

### DIFF
--- a/api/overview/azure/ai.anomalydetector-readme-pre.md
+++ b/api/overview/azure/ai.anomalydetector-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Services Anomaly Detector client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.AnomalyDetector, anomalydetector
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.formrecognizer-readme-pre.md
+++ b/api/overview/azure/ai.formrecognizer-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Services Form Recognizer client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.FormRecognizer, formrecognizer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.formrecognizer-readme.md
+++ b/api/overview/azure/ai.formrecognizer-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Services Form Recognizer client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.FormRecognizer, formrecognizer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.language.conversations-readme-pre.md
+++ b/api/overview/azure/ai.language.conversations-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Language Services Conversations client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.Language.Conversations, cognitivelanguage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.language.questionanswering-readme-pre.md
+++ b/api/overview/azure/ai.language.questionanswering-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Language Services Question Answering client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.Language.QuestionAnswering, cognitivelanguage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.language.questionanswering-readme.md
+++ b/api/overview/azure/ai.language.questionanswering-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Language Services Question Answering client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.Language.QuestionAnswering, cognitivelanguage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/03/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.metricsadvisor-readme-pre.md
+++ b/api/overview/azure/ai.metricsadvisor-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Metrics Advisor client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.MetricsAdvisor, metricsadvisor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.metricsadvisor-readme.md
+++ b/api/overview/azure/ai.metricsadvisor-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Metrics Advisor client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.MetricsAdvisor, metricsadvisor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.personalizer-readme-pre.md
+++ b/api/overview/azure/ai.personalizer-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Personalizer client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.Personalizer, personalizer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.textanalytics-readme-pre.md
+++ b/api/overview/azure/ai.textanalytics-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Services Text Analytics client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.TextAnalytics, textanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.textanalytics-readme.md
+++ b/api/overview/azure/ai.textanalytics-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Services Text Analytics client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.TextAnalytics, textanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/ai.translation.document-readme-pre.md
+++ b/api/overview/azure/ai.translation.document-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Services Document Translation client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.AI.Translation.Document, translator
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.purview.account-readme-pre.md
+++ b/api/overview/azure/analytics.purview.account-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Account client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Purview.Account, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.purview.administration-readme-pre.md
+++ b/api/overview/azure/analytics.purview.administration-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Administration client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Purview.Administration, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/19/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.purview.catalog-readme-pre.md
+++ b/api/overview/azure/analytics.purview.catalog-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Catalog client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Purview.Catalog, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.purview.scanning-readme-pre.md
+++ b/api/overview/azure/analytics.purview.scanning-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Scanning client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Purview.Scanning, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.synapse.accesscontrol-readme-pre.md
+++ b/api/overview/azure/analytics.synapse.accesscontrol-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Analytics Access Control client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Synapse.AccessControl, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.synapse.artifacts-readme-pre.md
+++ b/api/overview/azure/analytics.synapse.artifacts-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Analytics Artifacts client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Synapse.Artifacts, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.synapse.managedprivateendpoints-readme-pre.md
+++ b/api/overview/azure/analytics.synapse.managedprivateendpoints-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Analytics Managed Private Endpoints client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Synapse.ManagedPrivateEndpoints, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.synapse.monitoring-readme-pre.md
+++ b/api/overview/azure/analytics.synapse.monitoring-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Analytics Monitoring client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Synapse.Monitoring, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/analytics.synapse.spark-readme-pre.md
+++ b/api/overview/azure/analytics.synapse.spark-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Spark client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Analytics.Synapse.Spark, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.administration-readme-pre.md
+++ b/api/overview/azure/communication.administration-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Administration client library for .NET
 keywords: Azure, .net, SDK, API, Azure.Communication.Administration, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/16/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.callingserver-readme-pre.md
+++ b/api/overview/azure/communication.callingserver-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication CallingServer client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.CallingServer, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.chat-readme-pre.md
+++ b/api/overview/azure/communication.chat-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Chat client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Chat, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.chat-readme.md
+++ b/api/overview/azure/communication.chat-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Chat client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Chat, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.common-readme-pre.md
+++ b/api/overview/azure/communication.common-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Common client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Common, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.common-readme.md
+++ b/api/overview/azure/communication.common-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Common client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Common, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.identity-readme-pre.md
+++ b/api/overview/azure/communication.identity-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Identity client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Identity, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.identity-readme.md
+++ b/api/overview/azure/communication.identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Identity client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Identity, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.networktraversal-readme-pre.md
+++ b/api/overview/azure/communication.networktraversal-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Network Traversal client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.NetworkTraversal, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.phonenumbers-readme-pre.md
+++ b/api/overview/azure/communication.phonenumbers-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Phone Numbers client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.PhoneNumbers, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.phonenumbers-readme.md
+++ b/api/overview/azure/communication.phonenumbers-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Phone Numbers client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.PhoneNumbers, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.sms-readme-pre.md
+++ b/api/overview/azure/communication.sms-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication SMS client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Sms, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/communication.sms-readme.md
+++ b/api/overview/azure/communication.sms-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication SMS client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Communication.Sms, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/containers.containerregistry-readme-pre.md
+++ b/api/overview/azure/containers.containerregistry-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Container Registry client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Containers.ContainerRegistry, containerregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/core-readme.md
+++ b/api/overview/azure/core-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core shared client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Core, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/core.amqp-readme-pre.md
+++ b/api/overview/azure/core.amqp-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core AMQP shared client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Core.Amqp, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/core.amqp-readme.md
+++ b/api/overview/azure/core.amqp-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core AMQP shared client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Core.Amqp, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/core.experimental-readme-pre.md
+++ b/api/overview/azure/core.experimental-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Experimental shared client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Core.Experimental, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/data.appconfiguration-readme-pre.md
+++ b/api/overview/azure/data.appconfiguration-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure App Configuration client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Data.AppConfiguration, appconfiguration
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/data.appconfiguration-readme.md
+++ b/api/overview/azure/data.appconfiguration-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure App Configuration client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Data.AppConfiguration, appconfiguration
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/data.schemaregistry-readme-pre.md
+++ b/api/overview/azure/data.schemaregistry-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Schema Registry client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Data.SchemaRegistry, schemaregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/data.tables-readme-pre.md
+++ b/api/overview/azure/data.tables-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Tables client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Data.Tables, tables
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/data.tables-readme.md
+++ b/api/overview/azure/data.tables-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Tables client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Data.Tables, tables
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/digitaltwins.core-readme-pre.md
+++ b/api/overview/azure/digitaltwins.core-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure IoT Digital Twins client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.DigitalTwins.Core, iot
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/digitaltwins.core-readme.md
+++ b/api/overview/azure/digitaltwins.core-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure IoT Digital Twins client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.DigitalTwins.Core, iot
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/extensions.aspnetcore.configuration.secrets-readme.md
+++ b/api/overview/azure/extensions.aspnetcore.configuration.secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Azure.Extensions.AspNetCore.Configuration.Secrets, extensions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/18/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/extensions.aspnetcore.dataprotection.blobs-readme.md
+++ b/api/overview/azure/extensions.aspnetcore.dataprotection.blobs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Azure.Extensions.AspNetCore.DataProtection.Blobs, extensions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/extensions.aspnetcore.dataprotection.keys-readme.md
+++ b/api/overview/azure/extensions.aspnetcore.dataprotection.keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Azure.Extensions.AspNetCore.DataProtection.Keys, extensions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/identity-readme-pre.md
+++ b/api/overview/azure/identity-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Identity client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Identity, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/identity-readme.md
+++ b/api/overview/azure/identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Identity client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Identity, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/iot.deviceupdate-readme-pre.md
+++ b/api/overview/azure/iot.deviceupdate-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Device Update for IoT Hub client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.IoT.DeviceUpdate, iotdeviceupdate
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/23/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/iot.modelsrepository-readme-pre.md
+++ b/api/overview/azure/iot.modelsrepository-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure IoT Models Repository client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.IoT.ModelsRepository, modelsrepository
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/iot.timeseriesinsights-readme-pre.md
+++ b/api/overview/azure/iot.timeseriesinsights-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure IoT Time Series Insights client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.IoT.TimeSeriesInsights, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/27/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/latest/storage.blobs-readme.md
+++ b/api/overview/azure/latest/storage.blobs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/27/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/latest/storage.blobs.batch-readme.md
+++ b/api/overview/azure/latest/storage.blobs.batch-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs Batch client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs.Batch, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/latest/storage.common-readme.md
+++ b/api/overview/azure/latest/storage.common-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Common client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Common, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/latest/storage.files.datalake-readme.md
+++ b/api/overview/azure/latest/storage.files.datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Files Data Lake client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Files.DataLake, datalakestorage(gen2)
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/latest/storage.files.shares-readme.md
+++ b/api/overview/azure/latest/storage.files.shares-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Shares client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Files.Shares, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/latest/storage.queues-readme.md
+++ b/api/overview/azure/latest/storage.queues-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Queues, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/media.analytics.edge-readme-pre.md
+++ b/api/overview/azure/media.analytics.edge-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Live Video Analytics for IoT Edge client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Media.Analytics.Edge, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/media.videoanalyzer.edge-readme-pre.md
+++ b/api/overview/azure/media.videoanalyzer.edge-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Video Analyzer Edge client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Media.VideoAnalyzer.Edge, videoanalyzer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/27/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.eventgrid-readme-pre.md
+++ b/api/overview/azure/messaging.eventgrid-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.EventGrid, eventgrid
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.eventgrid-readme.md
+++ b/api/overview/azure/messaging.eventgrid-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.EventGrid, eventgrid
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.eventhubs-readme-pre.md
+++ b/api/overview/azure/messaging.eventhubs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.EventHubs, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.eventhubs-readme.md
+++ b/api/overview/azure/messaging.eventhubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.EventHubs, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.eventhubs.processor-readme-pre.md
+++ b/api/overview/azure/messaging.eventhubs.processor-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs Event Processor client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.EventHubs.Processor, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.eventhubs.processor-readme.md
+++ b/api/overview/azure/messaging.eventhubs.processor-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs Event Processor client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.EventHubs.Processor, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.servicebus-readme-pre.md
+++ b/api/overview/azure/messaging.servicebus-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.ServiceBus, servicebus
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.servicebus-readme.md
+++ b/api/overview/azure/messaging.servicebus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.ServiceBus, servicebus
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/messaging.webpubsub-readme-pre.md
+++ b/api/overview/azure/messaging.webpubsub-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Web PubSub service client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Messaging.WebPubSub, webpubsub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.batch-readme.md
+++ b/api/overview/azure/microsoft.azure.batch-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Batch, batch
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.core.spatial-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.core.spatial-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Core.Spatial, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.core.spatial-readme.md
+++ b/api/overview/azure/microsoft.azure.core.spatial-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Core.Spatial, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.core.spatial.newtonsoftjson-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.core.spatial.newtonsoftjson-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Core.Spatial.NewtonsoftJson, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.data.schemaregistry.apacheavro-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.data.schemaregistry.apacheavro-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Schema Registry Apache Avro client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro, schemaregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.eventhubs-readme.md
+++ b/api/overview/azure/microsoft.azure.eventhubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.EventHubs, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme.md
+++ b/api/overview/azure/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents, eventgrid
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.servicebus-readme.md
+++ b/api/overview/azure/microsoft.azure.servicebus-readme.md
@@ -1,8 +1,9 @@
 ---
 title: Azure Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.ServiceBus, servicebus
-author: maggiepint
-ms.author: magpint
+=======
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.servicebus-readme.md
+++ b/api/overview/azure/microsoft.azure.servicebus-readme.md
@@ -1,7 +1,6 @@
 ---
 title: Azure Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.ServiceBus, servicebus
-=======
 author: ramya-rao-a
 ms.author: ramyar
 ms.date: 11/08/2021

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.eventgrid-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.eventgrid-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs EventGrid client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.EventGrid, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.eventgrid-readme.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.eventgrid-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs EventGrid client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.EventGrid, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.eventhubs-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.eventhubs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Event Hubs client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.EventHubs, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.eventhubs-readme.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.eventhubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Event Hubs client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.EventHubs, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.servicebus-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.servicebus-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.ServiceBus, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.servicebus-readme.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.servicebus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.ServiceBus, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.storage-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.storage-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Blobs and Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.storage-readme.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.storage-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Blobs and Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage, webjobs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.storage.blobs-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.storage.blobs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Blobs client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage.Blobs, functions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.storage.blobs-readme.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.storage.blobs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Blobs client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage.Blobs, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.storage.queues-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.storage.queues-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage.Queues, functions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.storage.queues-readme.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.storage.queues-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage.Queues, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webjobs.extensions.webpubsub-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webjobs.extensions.webpubsub-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Web PubSub client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebJobs.Extensions.WebPubSub, webpubsub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.azure.webpubsub.common-readme-pre.md
+++ b/api/overview/azure/microsoft.azure.webpubsub.common-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Web PubSub Event Handler events data model client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.WebPubSub.Common, webpubsub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.batch-readme.md
+++ b/api/overview/azure/microsoft.batch-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, .net, SDK, API, Microsoft.Azure.Batch, batch
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/29/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.core.newtonsoftjson-readme-pre.md
+++ b/api/overview/azure/microsoft.core.newtonsoftjson-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Experimental shared client library for .NET
 keywords: Azure, .net, SDK, API, Microsoft.Azure.Core.NewtonsoftJson, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/07/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.core.newtonsoftjson-readme.md
+++ b/api/overview/azure/microsoft.core.newtonsoftjson-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Core.NewtonsoftJson, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.core.spatial-readme-pre.md
+++ b/api/overview/azure/microsoft.core.spatial-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, .net, SDK, API, Microsoft.Azure.Core.Spatial, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.core.spatial-readme.md
+++ b/api/overview/azure/microsoft.core.spatial-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Core.Spatial, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.core.spatial.newtonsoftjson-readme-pre.md
+++ b/api/overview/azure/microsoft.core.spatial.newtonsoftjson-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, .net, SDK, API, Microsoft.Azure.Core.Spatial.NewtonsoftJson, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.core.spatial.newtonsoftjson-readme.md
+++ b/api/overview/azure/microsoft.core.spatial.newtonsoftjson-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.Core.Spatial.NewtonsoftJson, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.data.schemaregistry.apacheavro-readme-pre.md
+++ b/api/overview/azure/microsoft.data.schemaregistry.apacheavro-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Schema Registry Apache Avro client library for .NET
 keywords: Azure, .net, SDK, API, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.eventhubs-readme.md
+++ b/api/overview/azure/microsoft.eventhubs-readme.md
@@ -2,8 +2,8 @@
 title: Azure Event Hubs client library for .NET - 4.3.1
 description: Azure Event Hubs client library for .NET - Version 4.3.1 
 keywords: Azure, .net, SDK, API, Microsoft.Azure.EventHubs, eventhub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2020
 ms.topic: reference
 ms.devlang: .net

--- a/api/overview/azure/microsoft.extensions.azure-readme-pre.md
+++ b/api/overview/azure/microsoft.extensions.azure-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Extensions.Azure, extensions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.extensions.azure-readme.md
+++ b/api/overview/azure/microsoft.extensions.azure-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, Microsoft.Extensions.Azure, extensions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.opentelemetry.exporter.azuremonitor-readme-pre.md
+++ b/api/overview/azure/microsoft.opentelemetry.exporter.azuremonitor-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor Exporter client library for .NET
 keywords: Azure, .net, SDK, API, Microsoft.OpenTelemetry.Exporter.AzureMonitor, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/10/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.servicebus-readme.md
+++ b/api/overview/azure/microsoft.servicebus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service Bus client library for .NET
 keywords: Azure, dotnet, SDK, API, Microsoft.Azure.ServiceBus, servicebus
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.webjobs.extensions.storage-readme-pre.md
+++ b/api/overview/azure/microsoft.webjobs.extensions.storage-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Blobs and Queues client library for .NET
 keywords: Azure, .net, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage, webjobsextensions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.webjobs.extensions.storage.blobs-readme-pre.md
+++ b/api/overview/azure/microsoft.webjobs.extensions.storage.blobs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Blobs client library for .NET
 keywords: Azure, .net, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage.Blobs, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/microsoft.webjobs.extensions.storage.queues-readme-pre.md
+++ b/api/overview/azure/microsoft.webjobs.extensions.storage.queues-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebJobs Storage Queues client library for .NET
 keywords: Azure, .net, SDK, API, Microsoft.Azure.WebJobs.Extensions.Storage.Queues, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/mixedreality.authentication-readme-pre.md
+++ b/api/overview/azure/mixedreality.authentication-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Mixed Reality Authentication client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.MixedReality.Authentication, mixedreality
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/mixedreality.authentication-readme.md
+++ b/api/overview/azure/mixedreality.authentication-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Mixed Reality Authentication client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.MixedReality.Authentication, mixedreality
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/mixedreality.objectanchors.conversion-readme-pre.md
+++ b/api/overview/azure/mixedreality.objectanchors.conversion-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Object Anchors client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.MixedReality.ObjectAnchors.Conversion, mixedreality
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/mixedreality.remoterendering-readme-pre.md
+++ b/api/overview/azure/mixedreality.remoterendering-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Remote Rendering client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.MixedReality.RemoteRendering, mixedreality
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/24/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/mixedreality.remoterendering-readme.md
+++ b/api/overview/azure/mixedreality.remoterendering-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Remote Rendering client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.MixedReality.RemoteRendering, mixedreality
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/17/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/monitor.opentelemetry.exporter-readme-pre.md
+++ b/api/overview/azure/monitor.opentelemetry.exporter-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor Exporter client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Monitor.OpenTelemetry.Exporter, monitor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/monitor.query-readme-pre.md
+++ b/api/overview/azure/monitor.query-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor Query client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Monitor.Query, monitor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/monitor.query-readme.md
+++ b/api/overview/azure/monitor.query-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor Query client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Monitor.Query, monitor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/quantum.jobs-readme-pre.md
+++ b/api/overview/azure/quantum.jobs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Quantum Jobs client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Quantum.Jobs, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/30/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager-readme-pre.md
+++ b/api/overview/azure/resourcemanager-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ResourceManager client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager, azureresourcemanager
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.appconfiguration-readme-pre.md
+++ b/api/overview/azure/resourcemanager.appconfiguration-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure App Configuration Management client library for .NET
 keywords: Azure, .net, SDK, API, Azure.ResourceManager.AppConfiguration, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/22/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.communication-readme-pre.md
+++ b/api/overview/azure/resourcemanager.communication-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Services management client library for .NET
 keywords: Azure, .net, SDK, API, Azure.ResourceManager.Communication, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/16/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.communication-readme.md
+++ b/api/overview/azure/resourcemanager.communication-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Services management client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager.Communication, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.compute-readme-pre.md
+++ b/api/overview/azure/resourcemanager.compute-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Compute Management client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager.Compute, compute
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.cosmosdb-readme-pre.md
+++ b/api/overview/azure/resourcemanager.cosmosdb-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure CosmosDB Management client library for .NET
 keywords: Azure, .net, SDK, API, Azure.ResourceManager.CosmosDB, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/24/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.dns-readme-pre.md
+++ b/api/overview/azure/resourcemanager.dns-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure dns Management client library for .NET
 keywords: Azure, .net, SDK, API, Azure.ResourceManager.Dns, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/24/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.eventhubs-readme-pre.md
+++ b/api/overview/azure/resourcemanager.eventhubs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs Management client library for .NET
 keywords: Azure, .net, SDK, API, Azure.ResourceManager.EventHubs, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/22/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.insights-readme-pre.md
+++ b/api/overview/azure/resourcemanager.insights-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Insights Management client library for .NET
 keywords: Azure, .net, SDK, API, Azure.ResourceManager.Insights, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/28/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.keyvault-readme-pre.md
+++ b/api/overview/azure/resourcemanager.keyvault-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Management client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager.KeyVault, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.network-readme-pre.md
+++ b/api/overview/azure/resourcemanager.network-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Network Management client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager.Network, virtualnetwork
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.resources-readme-pre.md
+++ b/api/overview/azure/resourcemanager.resources-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Resources Management client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager.Resources, resources
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/resourcemanager.storage-readme-pre.md
+++ b/api/overview/azure/resourcemanager.storage-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Management client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.ResourceManager.Storage, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/search.documents-readme-pre.md
+++ b/api/overview/azure/search.documents-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Search client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Search.Documents, search
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/search.documents-readme.md
+++ b/api/overview/azure/search.documents-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Search client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Search.Documents, search
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.attestation-readme-pre.md
+++ b/api/overview/azure/security.attestation-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Attestation client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.Attestation, attestation
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.attestation-readme.md
+++ b/api/overview/azure/security.attestation-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Attestation client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.Attestation, attestation
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.confidentialledger-readme-pre.md
+++ b/api/overview/azure/security.confidentialledger-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Confidential Ledger client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.ConfidentialLedger, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.administration-readme-pre.md
+++ b/api/overview/azure/security.keyvault.administration-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure KeyVault Administration client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Administration, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.administration-readme.md
+++ b/api/overview/azure/security.keyvault.administration-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure KeyVault Administration client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Administration, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.certificates-readme-pre.md
+++ b/api/overview/azure/security.keyvault.certificates-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificate client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Certificates, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.certificates-readme.md
+++ b/api/overview/azure/security.keyvault.certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificate client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Certificates, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.keys-readme-pre.md
+++ b/api/overview/azure/security.keyvault.keys-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault key client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Keys, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.keys-readme.md
+++ b/api/overview/azure/security.keyvault.keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault key client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Keys, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.secrets-readme-pre.md
+++ b/api/overview/azure/security.keyvault.secrets-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault secret client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Secrets, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/14/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/security.keyvault.secrets-readme.md
+++ b/api/overview/azure/security.keyvault.secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault secret client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Security.KeyVault.Secrets, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.blobs-readme-pre.md
+++ b/api/overview/azure/storage.blobs-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.blobs-readme.md
+++ b/api/overview/azure/storage.blobs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.blobs.batch-readme-pre.md
+++ b/api/overview/azure/storage.blobs.batch-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs Batch client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs.Batch, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.blobs.batch-readme.md
+++ b/api/overview/azure/storage.blobs.batch-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs Batch client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs.Batch, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.blobs.changefeed-readme-pre.md
+++ b/api/overview/azure/storage.blobs.changefeed-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blobs Change Feed client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Blobs.ChangeFeed, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.common-readme-pre.md
+++ b/api/overview/azure/storage.common-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Common client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Common, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/03/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.common-readme.md
+++ b/api/overview/azure/storage.common-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Common client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Common, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.confidentialledger-readme-pre.md
+++ b/api/overview/azure/storage.confidentialledger-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Confidential Ledger client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.ConfidentialLedger, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.files.datalake-readme-pre.md
+++ b/api/overview/azure/storage.files.datalake-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Files Data Lake client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Files.DataLake, datalakestorage(gen2)
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.files.datalake-readme.md
+++ b/api/overview/azure/storage.files.datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Files Data Lake client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Files.DataLake, datalakestorage(gen2)
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.files.shares-readme-pre.md
+++ b/api/overview/azure/storage.files.shares-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Shares client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Files.Shares, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.files.shares-readme.md
+++ b/api/overview/azure/storage.files.shares-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Shares client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Files.Shares, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.queues-readme-pre.md
+++ b/api/overview/azure/storage.queues-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Queues, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/storage.queues-readme.md
+++ b/api/overview/azure/storage.queues-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queues client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Storage.Queues, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/system.memory.data-readme-pre.md
+++ b/api/overview/azure/system.memory.data-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, .net, SDK, API, System.Memory.Data, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2020
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/system.memory.data-readme.md
+++ b/api/overview/azure/system.memory.data-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, dotnet, SDK, API, System.Memory.Data, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/template-readme-pre.md
+++ b/api/overview/azure/template-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Batch client library for Python
 keywords: Azure, dotnet, SDK, API, Azure.Template, template
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/api/overview/azure/verticals.agrifood.farming-readme-pre.md
+++ b/api/overview/azure/verticals.agrifood.farming-readme-pre.md
@@ -1,8 +1,8 @@
 ---
 title: Azure FarmBeats client library for .NET
 keywords: Azure, dotnet, SDK, API, Azure.Verticals.AgriFood.Farming, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/27/2021
 ms.topic: reference
 ms.prod: azure


### PR DESCRIPTION
**Motivation:**
We currently hard-coded `maggiepint`, `rloutlaw` into our docs metadata. The author metadata is used by Docs.Ms customer to reach out the docs content author. Maggie, and Robert are not here to serve Azure SDK anymore. The contact information has to be updated. 
**Short term approach**
We currently do a mass update for docs repo to update `Maggie` and `Robert` to team docs owner @ramya-rao-a. 

**Long term goal:**
We will have the release pipeline to pick up the CODEOWNERS from lang repo and update the metadata `author` and `msauthor` for package level readme.

For service level readme, we have to work on the automation first and we will work on a concrete plan since then.