### PR TITLE
Move Azure.Monitor.Query APIs to Monitor ToC node

### DIFF
--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -806,6 +806,11 @@
     uid: azure.net.sdk.landingPage.services.Monitor
     href: ~/api/overview/azure/monitor.md
     items:
+    - name: Query
+      uid: azure.net.sdk.landingPage.services.Monitor.Query
+      landingPageType: Service
+      children:
+      - 'Azure.Monitor.Query*'
     - name: Management
       uid: azure.net.sdk.landingPage.services.Monitor.Management
       landingPageType: Service


### PR DESCRIPTION
Currently, the Monitor Query API links appear under the "Other" ToC node. Move them to the "Monitor" ToC node.