### PR TITLE
Add missing Microsoft.Azure.Core-prefixed APIs to .NET ToC

### DIFF
--- a/docs-ref-toc/top_level_toc.yml
+++ b/docs-ref-toc/top_level_toc.yml
@@ -408,6 +408,7 @@
     children:
       - 'Azure'
       - 'Azure.Core*'
+      - 'Microsoft.Azure.Core*'
   - name: Cosmos DB
     uid: azure.net.sdk.landingPage.services.CosmosDB
     href: ~/api/overview/azure/cosmosdb.md


### PR DESCRIPTION
Adjust ToC to include APIs for the `Microsoft.Azure.Core`-prefixed NuGet packages.