### PR TITLE
Document how to select non-default AAD tenant

### DIFF
--- a/api/overview/azure/identity-readme.md
+++ b/api/overview/azure/identity-readme.md
@@ -94,6 +94,8 @@ The `DefaultAzureCredential` will attempt to authenticate via the following mech
  - Azure PowerShell - If the developer has authenticated an account via the Azure PowerShell `Connect-AzAccount` command, the `DefaultAzureCredential` will authenticate with that account.
  - Interactive - If enabled the `DefaultAzureCredential` will interactively authenticate the developer via the current system's default browser.
 
+> Override the default Azure Active Directory tenant by using the setting the `AZURE_TENANT_ID` environment variable or providing the `DefaultAzureCredential` constructor with `DefaultAzureCredentialOptions` and provide the tenant Id like `new DefaultAzureCredentialOptions( VisualStudioCodeTenantId = tenantId)`.
+
 ## Examples
 
 You can find more examples of using various credentials in [Azure Identity Examples Wiki page](https://github.com/Azure/azure-sdk-for-net/wiki/Azure-Identity-Examples).


### PR DESCRIPTION
If you have more than one AAD tenant, the default one is selected, which results authentication error for DefaultAzureCredential.