### PR TITLE
(AzureCXP) Fix permissions parameter description

### DIFF
--- a/xml/Azure.Storage.Sas/BlobSasBuilder.xml
+++ b/xml/Azure.Storage.Sas/BlobSasBuilder.xml
@@ -88,7 +88,7 @@
       </Parameters>
       <Docs>
         <param name="permissions">
-            The time at which the shared access signature becomes invalid.
+            This contains the list of permissions that can be set for a blob's access policy.
             This field must be omitted if it has been specified in an
             associated stored access policy.
             </param>


### PR DESCRIPTION
Fix the permissions parameter description for the BlobSasBuilder