### PR TITLE
[AppInsights] fix for incorrect hyperlink for Client API

### DIFF
--- a/api/overview/azure/insights.md
+++ b/api/overview/azure/insights.md
@@ -38,7 +38,7 @@ client.TrackEvent("MyCustomEvent");
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the client APIs](/dotnet/api/overview/azure/insights/client)
+> [Explore the client APIs](/dotnet/api/overview/azure/applicationinsights/client)
 
 
 


### PR DESCRIPTION
(Azure CXP) Fixes Azure/azure-sdk-for-net#21728

Incorrect link: https://docs.microsoft.com/en-us/dotnet/api/overview/azure/insights/client
Correction link: https://docs.microsoft.com/en-us/dotnet/api/overview/azure/applicationinsights/client