### PR TITLE
{azure-docs-sdk-dotnet} | Fixing unintelligent texts shown in our document

### DIFF
--- a/xml/Microsoft.Azure.Management.Sql.Models/RecommendedActionStateInfo.xml
+++ b/xml/Microsoft.Azure.Management.Sql.Models/RecommendedActionStateInfo.xml
@@ -56,29 +56,29 @@
       </Parameters>
       <Docs>
         <param name="currentValue">Current state the recommended action is
-            in. Some commonly used states are: Active      -&gt; recommended
-            action is active and no action has been taken yet. Pending
-            -&gt; recommended action is approved for and is awaiting execution.
-            Executing   -&gt; recommended action is being applied on the user
-            database. Verifying   -&gt; recommended action was applied and is
-            being verified of its usefulness by the system. Success     -&gt;
+            in. Some commonly used states are: 'Active': recommended
+            action is active and no action has been taken yet. 'Pending': 
+			recommended action is approved for and is awaiting execution.
+            Executing' recommended action is being applied on the user
+            database. 'Verifying': recommended action was applied and is
+            being verified of its usefulness by the system. 'Success':
             recommended action was applied and improvement found during
-            verification. Pending Revert  -&gt; verification found little or no
+            verification. 'Pending Revert': verification found little or no
             improvement so recommended action is queued for revert or user has
-            manually reverted. Reverting   -&gt; changes made while applying
+            manually reverted. 'Reverting' changes made while applying
             recommended action are being reverted on the user database.
-            Reverted    -&gt; successfully reverted the changes made by
-            recommended action on user database. Ignored     -&gt; user
+            'Reverted': successfully reverted the changes made by
+            recommended action on user database. 'Ignored': user
             explicitly ignored/discarded the recommended action. Possible
             values include: 'Active', 'Pending', 'Executing', 'Verifying',
-            'PendingRevert', 'RevertCancelled', 'Reverting', 'Reverted',
-            'Ignored', 'Expired', 'Monitoring', 'Resolved', 'Success',
-            'Error'</param>
+          'PendingRevert', 'RevertCancelled', 'Reverting', 'Reverted',
+          'Ignored', 'Expired', 'Monitoring', 'Resolved', 'Success',
+          'Error'</param>
         <param name="actionInitiatedBy">Gets who initiated the execution of
-            this recommended action. Possible Value are: User    -&gt; When
+            this recommended action. Possible Value are: 'User': When
             user explicity notified system to apply the recommended action.
-            System  -&gt; When auto-execute status of this advisor was set to
-            'Enabled', in which case the system applied it. Possible values
+            'System': When auto-execute status of this advisor was set to
+          'Enabled', in which case the system applied it. Possible values
             include: 'User', 'System'</param>
         <param name="lastModified">Gets the time when the state was last
             modified</param>
@@ -111,11 +111,10 @@
       <Docs>
         <summary>
             Gets who initiated the execution of this recommended action.
-            Possible Value are: User    -&amp;gt; When user explicity notified
-            system to apply the recommended action. System  -&amp;gt; When
+            Possible Value are: 'User': When user explicity notified
+            system to apply the recommended action. 'System': When
             auto-execute status of this advisor was set to 'Enabled', in which
-            case the system applied it. Possible values include: 'User',
-            'System'
+            case the system applied it. Possible values include: 'User', 'System'
             </summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
@@ -144,23 +143,22 @@
       <Docs>
         <summary>
             Gets or sets current state the recommended action is in. Some
-            commonly used states are: Active      -&amp;gt; recommended action
-            is active and no action has been taken yet. Pending     -&amp;gt;
+            commonly used states are: 'Active': recommended action
+            is active and no action has been taken yet. 'Pending':
             recommended action is approved for and is awaiting execution.
-            Executing   -&amp;gt; recommended action is being applied on the
-            user database. Verifying   -&amp;gt; recommended action was applied
-            and is being verified of its usefulness by the system. Success
-            -&amp;gt; recommended action was applied and improvement found
-            during verification. Pending Revert  -&amp;gt; verification found
+            'Executing': recommended action is being applied on the
+            user database. 'Verifying': recommended action was applied
+            and is being verified of its usefulness by the system. 'Success': recommended action was applied and improvement found
+            during verification. 'Pending Revert': verification found
             little or no improvement so recommended action is queued for revert
-            or user has manually reverted. Reverting   -&amp;gt; changes made
+            or user has manually reverted. 'Reverting': changes made
             while applying recommended action are being reverted on the user
-            database. Reverted    -&amp;gt; successfully reverted the changes
-            made by recommended action on user database. Ignored     -&amp;gt;
+            database. 'Reverted': successfully reverted the changes
+            made by recommended action on user database. 'Ignored':
             user explicitly ignored/discarded the recommended action. Possible
             values include: 'Active', 'Pending', 'Executing', 'Verifying',
-            'PendingRevert', 'RevertCancelled', 'Reverting', 'Reverted',
-            'Ignored', 'Expired', 'Monitoring', 'Resolved', 'Success', 'Error'
+          'PendingRevert', 'RevertCancelled', 'Reverting', 'Reverted',
+          'Ignored', 'Expired', 'Monitoring', 'Resolved', 'Success', 'Error'
             </summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
Special character are shown in document `&lt;br /&gt;&lt;br /&gt; 

eg., https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.upgradepolicy?view=azure-dotnet

Fixes https://github.com/Azure/azure-sdk-for-net/issues/23430