### PR TITLE
Retire ms.service: "application-insights"

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -125,11 +125,11 @@
         "api/global*.yml": "multiple",
         "api/KeyVault.TestFramework*.yml": "key-vault",
         "api/ManagedIdentityConnector*.yml": "azure-app-configuration",
-        "api/Microsoft.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.ApplicationInsights*.yml": "azure-monitor",
         "api/Azure.Analytics.Purview.Account*.yml": "purview",
         "api/Azure.ResourceManager.EdgeOrder*.yml": "edgeorder",
         "api/Microsoft.Azure.AppConfiguration*.yml": "azure-app-configuration",
-        "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.ApplicationInsights*.yml": "azure-monitor",
         "api/Microsoft.Azure.Batch*.yml": "batch",
         "api/Microsoft.Azure.CognitiveServices*.yml": "cognitive-services",
         "api/Microsoft.Azure.Cosmos*.yml": "cosmos-db",
@@ -258,6 +258,10 @@
         "api/TrackOne*.yml": "event-hubs",
         "docs-ref-conceptual/**/*.md": "multiple",
         "api/Azure*.yml": "azure"
+      },
+      "ms.subservice": {
+        "api/Microsoft.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights"
       },
       "products": {
         "api/Microsoft.Azure.Management.ContainerInstance*.yml": [


### PR DESCRIPTION
This is a bulk update to change ms.service: "application-insights" to ms.service: "azure-monitor" and add ms.subservice: "application-insights" per ceapex Allow List request: 565326