### PR TITLE
Retire ms.service: "resource-move"

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -191,7 +191,7 @@
         "api/Microsoft.Azure.Management.ManagedServices*.yml": "managed-applications",
         "api/Microsoft.Azure.Management.ManagementGroups*.yml": "resource-graph",
         "api/Microsoft.Azure.Management.Media*.yml": "media-services",
-        "api/Microsoft.Azure.Management.Migrate.ResourceMover*.yml": "resource-move",
+        "api/Microsoft.Azure.Management.Migrate.ResourceMover*.yml": "resource-mover",
         "api/Microsoft.Azure.Management.MixedReality*.yml": "mixed-reality",
         "api/Microsoft.Azure.Management.Monitor*.yml": "monitoring-and-diagnostics",
         "api/Microsoft.Azure.Management.MySQ*.yml": "mysql",


### PR DESCRIPTION
This is a bulk update to change ms.service: "resource-move" to ms.service: "resource-mover" per ceapex Allow List request: 573020