### PR TITLE
[Azure CXP]Fix Typo

### DIFF
--- a/xml/Microsoft.Azure.Documents.Client/RequestOptions.xml
+++ b/xml/Microsoft.Azure.Documents.Client/RequestOptions.xml
@@ -903,7 +903,7 @@
              The token for use with session consistency.
              </value>
         <remarks>
-             One of the <see cref="P:Microsoft.Azure.Documents.Client.RequestOptions.ConsistencyLevel" /> for Azure Cosmos DB is Session. In fact, this is the deault level applied to accounts.
+             One of the <see cref="P:Microsoft.Azure.Documents.Client.RequestOptions.ConsistencyLevel" /> for Azure Cosmos DB is Session. In fact, this is the default level applied to accounts.
              <para>
              When working with Session consistency, each new write request to Azure Cosmos DB is assigned a new SessionToken.
              The DocumentClient will use this token internally with each read/query request to ensure that the set consistency level is maintained.


### PR DESCRIPTION
spelling mistake "deault" should be default
Resolves #https://github.com/Azure/azure-sdk-for-net/issues/28482