### PR TITLE
fix moniker selector on overview pages

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -704,10 +704,20 @@
           "azure-dotnet",
           "azure-dotnet-preview",
           "azure-dotnet-legacy"
+        ],
+        "api/overview/azure/**/*.md": [
+          "azure-dotnet",
+          "azure-dotnet-preview",
+          "azure-dotnet-legacy"
         ]
       },
       "monikers": {
         "api/overview/azure/**/*.yml": [
+          "azure-dotnet",
+          "azure-dotnet-preview",
+          "azure-dotnet-legacy"
+        ],
+        "api/overview/azure/**/*.md": [
           "azure-dotnet",
           "azure-dotnet-preview",
           "azure-dotnet-legacy"

--- a/docfx.json
+++ b/docfx.json
@@ -3,8 +3,8 @@
     "content": [
       {
         "files": [
-          "overwrites/**/*.yml",
-          "overwrites/**/*.md"
+          "overview/azure/**/*.yml",
+          "overview/azure/**/*.md"
         ],
         "exclude": [
           "**/toc.yml",

--- a/docfx.json
+++ b/docfx.json
@@ -3,6 +3,19 @@
     "content": [
       {
         "files": [
+          "overwrites/**/*.yml",
+          "overwrites/**/*.md"
+        ],
+        "exclude": [
+          "**/toc.yml",
+          "**/includes/**"
+        ],
+        "src": "api",
+        "dest": "api",
+        "group": "all-monikers"
+      },
+      {
+        "files": [
           "**/*.yml",
           "**/*.md"
         ],
@@ -700,24 +713,7 @@
         ]
       },
       "version": {
-        "api/overview/azure/**/*.yml": [
-          "azure-dotnet",
-          "azure-dotnet-preview",
-          "azure-dotnet-legacy"
-        ],
-        "api/overview/azure/**/*.md": [
-          "azure-dotnet",
-          "azure-dotnet-preview",
-          "azure-dotnet-legacy"
-        ]
-      },
-      "monikers": {
-        "api/overview/azure/**/*.yml": [
-          "azure-dotnet",
-          "azure-dotnet-preview",
-          "azure-dotnet-legacy"
-        ],
-        "api/overview/azure/**/*.md": [
+        "api/overview/azure/**/*": [
           "azure-dotnet",
           "azure-dotnet-preview",
           "azure-dotnet-legacy"
@@ -810,6 +806,12 @@
     },
     "markdownEngineName": "markdig",
     "dest": "_site",
+    "groups": {
+      "all-monikers": {
+        "dest": "all",
+        "moniker_range": "azure-dotnet || azure-dotnet-preview || azure-dotnet-legacy"
+      }
+    },
     "template": [
       "docs.html"
     ],


### PR DESCRIPTION
This PR is to fix missing moniker selector for overview pages auto generated by build pipeline (`api/overview/azure/**/*.yml`) or written in markdown format (`api/overview/azure/**/*.md`).

Example: There is no moniker selector on https://docs.microsoft.com/en-us/dotnet/api/overview/azure/activedirectory?view=azure-dotnet that is authored in markdown format at https://github.com/Azure/azure-docs-sdk-dotnet/blob/live/api/overview/azure/activedirectory.md

With this PR, moniker selector will be available on overview pages (no matter whether they are generated in build pipeline or hand-written by content team in markdown files):

- Overview page (auto-generated): https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/?view=azure-dotnet&branch=pr-en-us-2196
- Service overview page (auto-generated): https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/apimanagement?view=azure-dotnet&branch=pr-en-us-2196
- Service overview page (hand-written md): https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/activedirectory?view=azure-dotnet&branch=pr-en-us-2196
- Data/management plane overview page (auto-generated): https://review.docs.microsoft.com/en-us/dotnet/api/overview/azure/apimanagement/management?view=azure-dotnet&branch=pr-en-us-2196