### PR TITLE
Update Client APIs link for Service Fabric's Overview Page

### DIFF
--- a/api/overview/azure/latest/service-fabric.md
+++ b/api/overview/azure/latest/service-fabric.md
@@ -56,7 +56,7 @@ fabricClient.ApplicationManager.CreateApplicationAsync(appDesc).Wait();
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the client APIs](/dotnet/api/overview/azure/servicefabric/client)
+> [Explore the client APIs](/dotnet/api/system.fabric.fabricclient)
 
 This example uses the Service Fabric **runtime** and **common** APIs from within a hosted application to update a [Reliable Collection](/azure/service-fabric/service-fabric-reliable-services-reliable-collections) at runtime.
 


### PR DESCRIPTION
The Client APIs link in the [Service Fabric's Overview](https://learn.microsoft.com/dotnet/api/overview/azure/service-fabric) page is broken and doesn't seem to have a similar page available in the reference docs.

This PR updates the link to point to the reference doc of the [`FabricClient`](https://learn.microsoft.com/dotnet/api/system.fabric.fabricclient) class which is the main class that exposes Client APIs as the next best alternative that I could think of.

Let me know if there is another page that should rather link to @rloutlaw 

resolves Azure/azure-sdk-for-net#32583