### PR TITLE
Fix Explore Client APIs Link

### DIFF
--- a/api/overview/azure/latest/cosmosdb.md
+++ b/api/overview/azure/latest/cosmosdb.md
@@ -49,7 +49,7 @@ using (CosmosClient cosmosClient = new CosmosClient("endpoint", "primaryKey"))
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the client APIs](/dotnet/api/overview/azure/cosmosdb/client)
+> [Explore the client APIs](/dotnet/api/overview/azure/cosmosdb/documentdb)
 
 ## Samples
 


### PR DESCRIPTION
Updating the link for the `Explore the Client APIs` button

resolves Azure/azure-sdk-for-net#32844