### PR TITLE
Metadata retagging - User story 774326

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -817,7 +817,8 @@
         "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights",
         "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "application-insights",
         "api/Microsoft.Azure.Media.LiveVideoAnalytics.Edge*.yml": "lva-edge",
-        "api/Microsoft.WindowsAzure.MobileServices*.yml": "mobile-apps"
+        "api/Microsoft.WindowsAzure.MobileServices*.yml": "mobile-apps",
+        "api/Microsoft.Azure.Management.WebSites*.yml": "web-apps"
       },
       "version": {
         "api/overview/azure/**/*.yml": [

--- a/docfx.json
+++ b/docfx.json
@@ -308,7 +308,7 @@
         "api/Microsoft.Azure.Management.Media*.yml": "media-services",
         "api/Microsoft.Azure.Management.Migrate.ResourceMover*.yml": "resource-mover",
         "api/Microsoft.Azure.Management.MixedReality*.yml": "mixed-reality",
-        "api/Microsoft.Azure.Management.Monitor*.yml": "monitoring-and-diagnostics",
+        "api/Microsoft.Azure.Management.Monitor*.yml": "monitoring-alerts",
         "api/Microsoft.Azure.Management.MySQ*.yml": "mysql",
         "api/Microsoft.Azure.Management.Network*.yml": "virtual-network",
         "api/Microsoft.Azure.Management.NotificationHubs*.yml": "notification-hubs",
@@ -340,7 +340,7 @@
         "api/Microsoft.Azure.Management.VideoAnalyzer*.yml": "azure-video-analyzer",
         "api/Microsoft.Azure.Management.WebSites*.yml": "app-service",
         "api/Microsoft.Azure.Management.WorkloadMonitor*.yml": "azure-monitor",
-        "api/Microsoft.Azure.Media.LiveVideoAnalytics.Edge*.yml": "media-services/lva-edge",
+        "api/Microsoft.Azure.Media.LiveVideoAnalytics.Edge*.yml": "media-services",
         "api/Microsoft.Azure.Mobile.Server*.yml": "app-service",
         "api/Microsoft.Azure.NotificationHubs*.yml": "notification-hubs",
         "api/Microsoft.Azure.OperationalInsights*.yml": "operational-insights",
@@ -815,7 +815,8 @@
       "ms.subservice": {
         "api/Microsoft.ApplicationInsights*.yml": "application-insights",
         "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights",
-        "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "application-insights"
+        "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.Media.LiveVideoAnalytics.Edge*.yml": "lva-edge"
       },
       "version": {
         "api/overview/azure/**/*.yml": [

--- a/docfx.json
+++ b/docfx.json
@@ -364,7 +364,7 @@
         "api/Microsoft.ServiceFabric*.yml": "service-fabric",
         "api/Microsoft.WindowsAzure.Management.StorSimple*.yml": "storsimple",
         "api/Microsoft.WindowsAzure.MediaServices*.yml": "media-services",
-        "api/Microsoft.WindowsAzure.MobileServices*.yml": "mobile-apps",
+        "api/Microsoft.WindowsAzure.MobileServices*.yml": "app-service",
         "api/Microsoft.WindowsAzure.Storage*.yml": "storage",
         "api/Microsoft.Xml.Serialization.GeneratedAssembly*.yml": "service-fabric",
         "api/System.Data.Sql*.yml": "sql-database",
@@ -816,7 +816,8 @@
         "api/Microsoft.ApplicationInsights*.yml": "application-insights",
         "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights",
         "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "application-insights",
-        "api/Microsoft.Azure.Media.LiveVideoAnalytics.Edge*.yml": "lva-edge"
+        "api/Microsoft.Azure.Media.LiveVideoAnalytics.Edge*.yml": "lva-edge",
+        "api/Microsoft.WindowsAzure.MobileServices*.yml": "mobile-apps"
       },
       "version": {
         "api/overview/azure/**/*.yml": [

--- a/docfx.json
+++ b/docfx.json
@@ -239,11 +239,11 @@
         "api/global*.yml": "multiple",
         "api/KeyVault.TestFramework*.yml": "key-vault",
         "api/ManagedIdentityConnector*.yml": "azure-app-configuration",
-        "api/Microsoft.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.ApplicationInsights*.yml": "azure-monitor",
         "api/Azure.Analytics.Purview.Account*.yml": "purview",
         "api/Azure.ResourceManager.EdgeOrder*.yml": "edgeorder",
         "api/Microsoft.Azure.AppConfiguration*.yml": "azure-app-configuration",
-        "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.ApplicationInsights*.yml": "azure-monitor",
         "api/Microsoft.Azure.Batch*.yml": "batch",
         "api/Microsoft.Azure.CognitiveServices*.yml": "cognitive-services",
         "api/Microsoft.Azure.Cosmos*.yml": "cosmos-db",
@@ -258,7 +258,7 @@
         "api/Microsoft.Azure.KeyVault*.yml": "key-vault",
         "api/Microsoft.Azure.Management.Advisor*.yml": "advisor",
         "api/Microsoft.Azure.Management.ApiManagement*.yml": "api-management",
-        "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "azure-monitor",
         "api/Microsoft.Azure.Management.AppPlatform*.yml": "spring-cloud",
         "api/Microsoft.Azure.Management.AppService*.yml": "app-service",
         "api/Microsoft.Azure.Management.Authorization*.yml": "azure-resource-manager",
@@ -306,7 +306,7 @@
         "api/Microsoft.Azure.Management.ManagedServices*.yml": "managed-applications",
         "api/Microsoft.Azure.Management.ManagementGroups*.yml": "resource-graph",
         "api/Microsoft.Azure.Management.Media*.yml": "media-services",
-        "api/Microsoft.Azure.Management.Migrate.ResourceMover*.yml": "resource-move",
+        "api/Microsoft.Azure.Management.Migrate.ResourceMover*.yml": "resource-mover",
         "api/Microsoft.Azure.Management.MixedReality*.yml": "mixed-reality",
         "api/Microsoft.Azure.Management.Monitor*.yml": "monitoring-and-diagnostics",
         "api/Microsoft.Azure.Management.MySQ*.yml": "mysql",
@@ -323,7 +323,7 @@
         "api/Microsoft.Azure.Management.Redis*.yml": "cache",
         "api/Microsoft.Azure.Management.ResourceGraph*.yml": "resource-graph",
         "api/Microsoft.Azure.Management.ResourceManager*.yml": "azure-resource-manager",
-        "api/Microsoft.Azure.Management.Search*.yml": "search",
+        "api/Microsoft.Azure.Management.Search*.yml": "cognitive-search",
         "api/Microsoft.Azure.Management.ServiceBus*.yml": "service-bus-messaging",
         "api/Microsoft.Azure.Management.ServiceFabric*.yml": "service-fabric",
         "api/Microsoft.Azure.Management.Sql*.yml": "sql-database",
@@ -364,7 +364,7 @@
         "api/Microsoft.ServiceFabric*.yml": "service-fabric",
         "api/Microsoft.WindowsAzure.Management.StorSimple*.yml": "storsimple",
         "api/Microsoft.WindowsAzure.MediaServices*.yml": "media-services",
-        "api/Microsoft.WindowsAzure.MobileServices*.yml": "app-service-mobile",
+        "api/Microsoft.WindowsAzure.MobileServices*.yml": "mobile-apps",
         "api/Microsoft.WindowsAzure.Storage*.yml": "storage",
         "api/Microsoft.Xml.Serialization.GeneratedAssembly*.yml": "service-fabric",
         "api/System.Data.Sql*.yml": "sql-database",
@@ -811,6 +811,11 @@
         "api/TrackOne*.yml": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/f0234678-3067-4edc-abf7-8142d54bb7d2"
         ]
+      },
+      "ms.subservice": {
+        "api/Microsoft.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.ApplicationInsights*.yml": "application-insights",
+        "api/Microsoft.Azure.Management.ApplicationInsights*.yml": "application-insights"
       },
       "version": {
         "api/overview/azure/**/*.yml": [


### PR DESCRIPTION
Metadata cleanup for the following ms.service values:
- resource-move replaced with resource-mover
- search replaced with cognitive-search
- app-service-mobile replaced with app-service and ms.subservice = mobile-apps
- application-insights replaced with azure-monitor and ms.subservice = application-insights
- added ms.service=web-apps where ms.service = app-service

For details about this work, see [User story 774326](https://ceapex.visualstudio.com/CPS/_workitems/edit/774326)