### PR TITLE
[AppAuth] Update note to reflect retirement

### DIFF
--- a/api/overview/azure/latest/service-to-service-authentication.md
+++ b/api/overview/azure/latest/service-to-service-authentication.md
@@ -13,9 +13,8 @@ ms.prod: azure
 # App Authentication client library for .NET - version 1.6.0
 
 > [!NOTE]
-> **Microsoft.Azure.Services.AppAuthentication** is no longer recommended to use with new Azure SDK. 
-> It is replaced with new **Azure Identity client library** available for .NET, Java, TypeScript and Python and should be used for all new development. 
-> Information about how to migrate to `Azure Identity`can be found here: [AppAuthentication to Azure.Identity Migration Guidance](app-auth-migration.md).
+> **Microsoft.Azure.Services.AppAuthentication** has been retired and is no longer supported or maintained. 
+> It is replaced by the **Azure Identity client library** available for .NET, Java, TypeScript and Python. Information about how to migrate to `Azure Identity`can be found here: [AppAuthentication to Azure.Identity Migration Guidance](app-auth-migration.md).
 
 To authenticate to Azure services with service principal, you need an Azure Active Directory (Azure AD) credential, either a shared secret or a certificate.
 


### PR DESCRIPTION
The focus of these changes is to update the note discussing deprecation of the library to reflect that it has now been retired, de-listed, and is no longer supported.