### PR TITLE
Fix "AKV management client library for .NET" page

### DIFF
--- a/api/overview/azure/latest/resourcemanager.keyvault-readme.md
+++ b/api/overview/azure/latest/resourcemanager.keyvault-readme.md
@@ -20,11 +20,11 @@ This library supports managing Microsoft Azure Key Vault resources.
 
 This library follows the [new Azure SDK guidelines](https://azure.github.io/azure-sdk/general_introduction.html), and provides many core capabilities:
 
-    - Support MSAL.NET, Azure.Identity is out of box for supporting MSAL.NET.
-    - Support [OpenTelemetry](https://opentelemetry.io/) for distributed tracing.
-    - HTTP pipeline with custom policies.
-    - Better error-handling.
-    - Support uniform telemetry across all languages.
+- Support MSAL.NET, Azure.Identity is out of box for supporting MSAL.NET.
+- Support [OpenTelemetry](https://opentelemetry.io/) for distributed tracing.
+- HTTP pipeline with custom policies.
+- Better error-handling.
+- Support uniform telemetry across all languages.
 
 ## Getting started
 


### PR DESCRIPTION
Right now the [page](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.keyvault-readme) looks like this:

![image](https://user-images.githubusercontent.com/6381023/231793529-2292a7b8-c740-49c1-a3da-159d25ca92ac.png)
