### PR TITLE
{AzureDataLakeStore} Fix for the broken link to AdlsClient 

### DIFF
--- a/api/overview/azure/latest/data-lake-store.md
+++ b/api/overview/azure/latest/data-lake-store.md
@@ -45,7 +45,7 @@ AdlsClient client = AdlsClient.CreateClient(_adlsAccountName, adlCreds);
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the client APIs](/dotnet/api/overview/azure/datalakestore/client)
+> [Explore the client APIs](/dotnet/api/microsoft.azure.datalake.store.adlsclient)
 
 
 ## Management library


### PR DESCRIPTION
fixes Azure/azure-sdk-for-net#36626

Old Link:
New Link: /dotnet/api/microsoft.azure.datalake.store.adlsclient