### PR TITLE
Brianem/speech 1.30.0 updates

### DIFF
--- a/metadata/latest/Microsoft.CognitiveServices.Speech.Remoteconversation.json
+++ b/metadata/latest/Microsoft.CognitiveServices.Speech.Remoteconversation.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.CognitiveServices.Speech.Remoteconversation",
-  "Version": "1.27.0",
+  "Version": "1.30.0",
   "Namespaces": "Microsoft.CognitiveServices.Speech.RemoteConversation",
   "DocsCiConfigProperties": "",
   "MSDocService": "placeholder",

--- a/metadata/latest/Microsoft.CognitiveServices.Speech.json
+++ b/metadata/latest/Microsoft.CognitiveServices.Speech.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.CognitiveServices.Speech",
-  "Version": "1.28.0",
+  "Version": "1.30.0",
   "Namespaces": [
     "Azure.AI.Vision.Common.Internal",
     "Microsoft.CognitiveServices.Speech",

--- a/metadata/preview/Azure.AI.Vision.Common.json
+++ b/metadata/preview/Azure.AI.Vision.Common.json
@@ -1,0 +1,12 @@
+{
+  "Name": "Azure.AI.Vision.Common",
+  "Version": "0.13.0-beta.1",
+  "Namespaces": [
+    "Azure.AI.Vision.Common"
+  ],
+  "DocsCiConfigProperties": "tfm=netstandard2.0",
+  "MSDocService": "placeholder",
+  "ServiceDirectory": "NA",
+  "SdkType": "client",
+  "IsNewSdk": false
+}

--- a/metadata/preview/Azure.AI.Vision.ImageAnalysis.json
+++ b/metadata/preview/Azure.AI.Vision.ImageAnalysis.json
@@ -1,6 +1,6 @@
 {
   "Name": "Azure.AI.Vision.ImageAnalysis",
-  "Version": "0.11.1-beta.1",
+  "Version": "0.13.0-beta.1",
   "Namespaces": "Azure.AI.Vision.ImageAnalysis",
   "ServiceDirectory": "https://msasg.visualstudio.com/Skyman/_git/Carbon",
   "SdkType": "client",


### PR DESCRIPTION
@danieljurek 
@JimSuplizio

You can ignore the previous 1.28.0 release PR that is still pending, and just get caught up on the current 1.30.0 release.