### PR TITLE
{Azure Functions} Nuget package for Azure Functions used in Isolated Process should be mentioned.

### DIFF
--- a/api/overview/azure/latest/microsoft.azure.webjobs.extensions.storage.blobs-readme.md
+++ b/api/overview/azure/latest/microsoft.azure.webjobs.extensions.storage.blobs-readme.md
@@ -23,6 +23,8 @@ Install the Storage Blobs extension with [NuGet][nuget]:
 dotnet add package Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 ```
 
+For isolated worker process functions, use [Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs nuget package](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs).
+
 ### Prerequisites
 
 You need an [Azure subscription][azure_sub] and a


### PR DESCRIPTION
Docs: https://learn.microsoft.com/en-us/dotnet/api/overview/azure/microsoft.azure.webjobs.extensions.storage.blobs-readme?view=azure-dotnet
This document should perhaps say at the top that the package is not compatible with Azure Functions used in Isolated Process mode; this can only be used with an in-process Azure Functions app. This will avoid confusion mong our customers.
As the isolated functions use : [Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs NuGet package](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs), version 5.x.

fixes Azure/azure-sdk-for-net#37957