### PR TITLE
Update Microsoft.Azure.Management.Compute.json doc with 61.0.0

### DIFF
--- a/metadata/latest/Microsoft.Azure.Management.Compute.json
+++ b/metadata/latest/Microsoft.Azure.Management.Compute.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.Management.Compute",
-  "Version": "59.0.0",
+  "Version": "61.0.0",
   "Namespaces": [
     "Microsoft.Azure.Management.Compute",
     "Microsoft.Azure.Management.Compute.Models"


### PR DESCRIPTION
I know that it is deprecated, but the last package that was released is 61.0.0 [https://www.nuget.org/packages/Microsoft.Azure.Management.Compute](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FMicrosoft.Azure.Management.Compute&data=05%7C01%7CTheodore.Chang%40microsoft.com%7C23de10aa52bf449eee2408dbaf1c1639%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638296307393408325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=TnRZFHS6aYPfK7PH23VZb8ldP4FGpw60UlKW%2FfpcW3I%3D&reserved=0)
But the documentations are showing 59.0.0 version. Can this be updated? [https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.restorepoint?view=azure-dotnet](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fdotnet%2Fapi%2Fmicrosoft.azure.management.compute.models.restorepoint%3Fview%3Dazure-dotnet&data=05%7C01%7CTheodore.Chang%40microsoft.com%7C23de10aa52bf449eee2408dbaf1c1639%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638296307393408325%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Pd0GAOuL6hMPPjy4VuVuHd0aq%2BsH%2F5JpVqMVwciK%2FIQ%3D&reserved=0)