### PR TITLE
Update Microsoft.Azure.Cosmos.json to 3.35.4 release

### DIFF
--- a/metadata/latest/Microsoft.Azure.Cosmos.json
+++ b/metadata/latest/Microsoft.Azure.Cosmos.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.Cosmos",
-  "Version": "3.31.2",
+  "Version": "3.35.4",
   "Namespaces": [
     "Microsoft.Azure.Cosmos",
     "Microsoft.Azure.Cosmos.Fluent",
@@ -10,7 +10,7 @@
   ],
   "DocsCiConfigProperties": {},
   "MSDocService": "placeholder",
-  "ServiceDirectory": "https://github.com/Azure/azure-cosmos-dotnet-v3/tree/3.31.2/Microsoft.Azure.Cosmos",
+  "ServiceDirectory": "https://github.com/Azure/azure-cosmos-dotnet-v3/tree/3.35.4/Microsoft.Azure.Cosmos",
   "SdkType": "client",
   "IsNewSdk": false,
   "DirectoryPath": ""


### PR DESCRIPTION
SDK 3.35.4 was released and API docs have not been updated for a while.

Closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4084