### PR TITLE
Update AzureActiveDirectoryRegistration.xml openIdIssuer example URL

### DIFF
--- a/xml/Microsoft.Azure.Management.WebSites.Models/AzureActiveDirectoryRegistration.xml
+++ b/xml/Microsoft.Azure.Management.WebSites.Models/AzureActiveDirectoryRegistration.xml
@@ -67,7 +67,7 @@
             application.
             When using Azure Active Directory, this value is the URI of the
             directory tenant, e.g.
-            https://login.microsoftonline.com/v2.0/{tenant-guid}/.
+            https://login.microsoftonline.com/{tenant-guid}/v2.0
             This URI is a case-sensitive identifier for the token issuer.
             More information on OpenID Connect Discovery:
             http://openid.net/specs/openid-connect-discovery-1_0.html</param>
@@ -287,7 +287,7 @@
             entity which issues access tokens for this application.
             When using Azure Active Directory, this value is the URI of the
             directory tenant, e.g.
-            https://login.microsoftonline.com/v2.0/{tenant-guid}/.
+            https://login.microsoftonline.com/{tenant-guid}/v2.0
             This URI is a case-sensitive identifier for the token issuer.
             More information on OpenID Connect Discovery:
             http://openid.net/specs/openid-connect-discovery-1_0.html


### PR DESCRIPTION
Using the incorrect token issuer URL: `https://login.microsoftonline.com/v2.0/{tenant-guid}/` results in error: `500 Unable to download OpenID Connect Configuration.`
The URL parameters should be switched around, like this: `https://login.microsoftonline.com/{tenant-guid}/v2.0` then the API call works.