### PR TITLE
Fix TFM for Microsoft.WCF.Azure.StorageQueues

### DIFF
--- a/bundlepackages/azure-dotnet-preview.csv
+++ b/bundlepackages/azure-dotnet-preview.csv
@@ -308,5 +308,5 @@ microsoftcorewcfazurestoragequeues,[tfm=netstandard2.0;isPrerelease=true]Microso
 microsoftextensionsconfigurationazureappconfiguration,[isPrerelease=true;tfm=netstandard2.0]Microsoft.Extensions.Configuration.AzureAppConfiguration,8.0.0-preview.3
 microsoftfeaturemanagement,[isPrerelease=true;tfm=netstandard2.0]Microsoft.FeatureManagement,2.6.0-preview2
 microsoftfeaturemanagementaspnetcore,[isPrerelease=true;tfm=netstandard2.0]Microsoft.FeatureManagement.AspNetCore,3.0.0-preview
-microsoftwcfazurestoragequeues,[tfm=netstandard2.0;isPrerelease=true]Microsoft.WCF.Azure.StorageQueues,1.0.0-beta.1
+microsoftwcfazurestoragequeues,[tfm=net6.0;isPrerelease=true]Microsoft.WCF.Azure.StorageQueues,1.0.0-beta.1
 systemclientmodel,[tfm=netstandard2.0;isPrerelease=true]System.ClientModel,1.1.0-beta.5

--- a/metadata/preview/Microsoft.WCF.Azure.StorageQueues.json
+++ b/metadata/preview/Microsoft.WCF.Azure.StorageQueues.json
@@ -15,5 +15,9 @@
     "Microsoft.WCF.Azure",
     "Microsoft.WCF.Azure.StorageQueues",
     "Microsoft.WCF.Azure.StorageQueues.Channels"
-  ]
+  ],
+  "DocsCiConfigProperties": {
+    "isPrerelease": "true",
+    "tfm": "net6.0"
+  }
 }


### PR DESCRIPTION
The TFM is hard coded to netstandard2.0 in automation and Microsoft.WCF.Azure.StorageQueues targets a different framework. This is a fix to get the contentCI pipeline off the floor. So main can be pushed to live, which hasn't been happening because someone changed docfx.json, which requires a manual merge to live that I can't do with content CI build failing.