### PR TITLE
Add docfx.json to the allow list for automatic merging from main->live

### DIFF
--- a/docsms-allowlist/dotnet-allowlist.txt
+++ b/docsms-allowlist/dotnet-allowlist.txt
@@ -3,3 +3,4 @@
 ^docs-ref-toc/
 ^metadata/
 ^xml/
+docfx.json


### PR DESCRIPTION
The azure-sdk team has an [automated pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=5213&_a=summary) which merges main->live every Wednesday at 4am PDT. Each repository has a <lang>-allowlist.txt file which includes patterns that are safe to merge. docfx.json is not in this list, mainly because there were two live site incidents related to changes to docfx.json. Recently, the pipelines have blocked merges because of changes to docfx.json which have been coming from other automated Learn sources. @nickwalkmsft and I chatted and decided to relax the restriction and allow changes to docfx.json to be merged.

This same change is being made to the following docs repositories:

- Azure/azure-docs-sdk-dotnet
- Azure/azure-docs-sdk-java
- MicrosoftDocs/azure-docs-sdk-node
- MicrosoftDocs/azure-docs-sdk-python
