### PR TITLE
Add docsms-allowlist directory to allow list for the repository

### DIFF
--- a/docsms-allowlist/dotnet-allowlist.txt
+++ b/docsms-allowlist/dotnet-allowlist.txt
@@ -3,4 +3,5 @@
 ^docs-ref-toc/
 ^metadata/
 ^xml/
+^docsms-allowlist/
 docfx.json


### PR DESCRIPTION
My preview PR updated the allow list and that change failed the auto-merge. The allow list isn't a file that's often updated and, even then, is only updated by hand, not automation. Don't prevent the auto-merge from main->live for allow list changes.