### PR TITLE
Exclude publishing of -index.md files in docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -5,6 +5,7 @@
         "files": [
           "**/*.yml"
         ],
+
         "src": "api/overview/legacy/azure",
         "dest": "api/overview/azure",
         "group": "legacy"
@@ -33,7 +34,8 @@
         "exclude": [
           "**/toc.yml",
           "overwrites/**/*",
-          "**/includes/**"
+          "**/includes/**",
+          "**/*-index.md"
         ],
         "src": "api/overview/azure/legacy",
         "dest": "api/overview/azure",
@@ -47,7 +49,8 @@
         "exclude": [
           "**/toc.yml",
           "overwrites/**/*",
-          "**/includes/**"
+          "**/includes/**",
+          "**/*-index.md"
         ],
         "src": "api/overview/azure/latest",
         "dest": "api/overview/azure",
@@ -61,7 +64,8 @@
         "exclude": [
           "**/toc.yml",
           "overwrites/**/*",
-          "**/includes/**"
+          "**/includes/**",
+          "**/*-index.md"
         ],
         "src": "api/overview/azure/preview",
         "dest": "api/overview/azure",
@@ -76,7 +80,8 @@
           "**/toc.yml",
           "overwrites/**/*",
           "**/includes/**",
-          "api/overview/azure/**"
+          "api/overview/azure/**",
+          "**/*-index.md"
         ],
         "src": "api",
         "dest": "api",
@@ -928,8 +933,8 @@
           "Azure",
           "Azure SDK for .NET"
         ]
-      }, 
-      "ms.author": { 
+      },
+      "ms.author": {
         "api/**": "azsdkdocs"
       },
       "author": {


### PR DESCRIPTION
The -index.md files are consumed by service-level overview pages and as such should not be published.

#Fixes https://github.com/Azure/azure-sdk-for-net/issues/37620
