### PR TITLE
Remove deprecated ms.prod and ms.technology metadata from readmes

### DIFF
--- a/api/overview/azure/cognitiveservices/bing-autosuggest-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-autosuggest-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Autosuggest
 

--- a/api/overview/azure/cognitiveservices/bing-custom-search-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-custom-search-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Custom Search
 

--- a/api/overview/azure/cognitiveservices/bing-entity-search-api-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-entity-search-api-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Entity Search
 

--- a/api/overview/azure/cognitiveservices/bing-image-search-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-image-search-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Image Search
 

--- a/api/overview/azure/cognitiveservices/bing-news-search-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-news-search-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing News Search
 

--- a/api/overview/azure/cognitiveservices/bing-spell-check-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-spell-check-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Spell Check
 

--- a/api/overview/azure/cognitiveservices/bing-video-search-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-video-search-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Video Search
 

--- a/api/overview/azure/cognitiveservices/bing-visual-search-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-visual-search-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Visual Search
 

--- a/api/overview/azure/cognitiveservices/bing-web-search-api-readme.md
+++ b/api/overview/azure/cognitiveservices/bing-web-search-api-readme.md
@@ -4,8 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: csharp
 ms.service: bing-search-services
-ms.technology: azure
-ms.prod: azure
 ---
 # Bing Web Search API
 

--- a/api/overview/azure/cognitiveservices/face-readme.md
+++ b/api/overview/azure/cognitiveservices/face-readme.md
@@ -4,8 +4,6 @@ ms.date: 06/21/2021
 ms.topic: reference
 ms.devlang: csharp
 ms.service: face-api
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Face API
 

--- a/api/overview/azure/latest/ai.metricsadvisor-readme.md
+++ b/api/overview/azure/latest/ai.metricsadvisor-readme.md
@@ -5,8 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: metricsadvisor
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Metrics Advisor client library for .NET - version 1.1.0 
 

--- a/api/overview/azure/latest/app-auth-migration.md
+++ b/api/overview/azure/latest/app-auth-migration.md
@@ -5,7 +5,6 @@ keywords: Azure, .net, SDK, API, Azure.Identity, identity
 ms.date: 10/27/2020
 ms.topic: reference
 ms.devlang: .net
-ms.prod: azure
 ---
 # AppAuthentication to Azure.Identity Migration Guidance
 

--- a/api/overview/azure/latest/communication.networktraversal-readme.md
+++ b/api/overview/azure/latest/communication.networktraversal-readme.md
@@ -5,8 +5,6 @@ ms.date: 02/09/2022
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: communication
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Communication Network Traversal client library for .NET - version 1.0.0 
 

--- a/api/overview/azure/latest/communication.sms-readme.md
+++ b/api/overview/azure/latest/communication.sms-readme.md
@@ -5,8 +5,6 @@ ms.date: 05/25/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: communication
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Communication SMS client library for .NET - version 1.0.1 
 

--- a/api/overview/azure/latest/microsoft.azure.core.spatial-readme.md
+++ b/api/overview/azure/latest/microsoft.azure.core.spatial-readme.md
@@ -5,8 +5,6 @@ ms.date: 06/10/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # System.Text.Json support for Microsoft.Spatial library for .NET
 

--- a/api/overview/azure/latest/microsoft.azure.eventhubs-readme.md
+++ b/api/overview/azure/latest/microsoft.azure.eventhubs-readme.md
@@ -5,8 +5,6 @@ ms.date: 05/06/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: eventhubs
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Event Hubs client library for .NET - version 4.3.2 
 

--- a/api/overview/azure/latest/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme.md
+++ b/api/overview/azure/latest/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/07/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: eventgrid
-ms.technology: azure
-ms.prod: azure
 ---
 # CloudNative CloudEvent support for Azure.Messaging.EventGrid library for .NET
 

--- a/api/overview/azure/latest/microsoft.azure.servicebus-readme.md
+++ b/api/overview/azure/latest/microsoft.azure.servicebus-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: servicebus
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Service Bus client library for .NET - version 5.2.0 
 

--- a/api/overview/azure/latest/microsoft.batch-readme.md
+++ b/api/overview/azure/latest/microsoft.batch-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/29/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: batch
-ms.technology: azure
-ms.prod: azure
 ---
 # License notes
 The Azure Batch C# client is now under the MIT license. Prior to March 10 2017 it was under the Apache 2.0 license.

--- a/api/overview/azure/latest/microsoft.core.newtonsoftjson-readme.md
+++ b/api/overview/azure/latest/microsoft.core.newtonsoftjson-readme.md
@@ -5,8 +5,6 @@ ms.date: 01/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # Newtonsoft.Json support for Azure Core shared client library for .NET
 

--- a/api/overview/azure/latest/microsoft.core.spatial-readme.md
+++ b/api/overview/azure/latest/microsoft.core.spatial-readme.md
@@ -5,8 +5,6 @@ ms.date: 01/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # System.Text.Json support for Microsoft.Spatial library for .NET
 

--- a/api/overview/azure/latest/microsoft.core.spatial.newtonsoftjson-readme.md
+++ b/api/overview/azure/latest/microsoft.core.spatial.newtonsoftjson-readme.md
@@ -5,8 +5,6 @@ ms.date: 01/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # Newtonsoft.Json support for Microsoft.Spatial library for .NET
 

--- a/api/overview/azure/latest/microsoft.servicebus-readme.md
+++ b/api/overview/azure/latest/microsoft.servicebus-readme.md
@@ -5,8 +5,6 @@ ms.date: 01/13/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: servicebus
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Service Bus client library for .NET - version 5.1.1 
 

--- a/api/overview/azure/latest/mixedreality.remoterendering-readme.md
+++ b/api/overview/azure/latest/mixedreality.remoterendering-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/17/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: mixedreality
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Remote Rendering client library for .NET - version 1.1.0 
 

--- a/api/overview/azure/latest/security.attestation-readme.md
+++ b/api/overview/azure/latest/security.attestation-readme.md
@@ -5,8 +5,6 @@ ms.date: 05/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: attestation
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Attestation client library for .NET - version 1.0.0 
 

--- a/api/overview/azure/latest/service-to-service-authentication.md
+++ b/api/overview/azure/latest/service-to-service-authentication.md
@@ -5,7 +5,6 @@ keywords: Azure, .net, SDK, API, Azure.Identity, identity
 ms.date: 10/27/2020
 ms.topic: reference
 ms.devlang: .net
-ms.prod: azure
 ---
 # App Authentication client library for .NET - version 1.6.0
 

--- a/api/overview/azure/latest/system.memory.data-readme.md
+++ b/api/overview/azure/latest/system.memory.data-readme.md
@@ -5,8 +5,6 @@ ms.date: 04/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 #  System.Memory.Data library for .NET
 

--- a/api/overview/azure/legacy/microsoft.opentelemetry.exporter.azuremonitor-readme.md
+++ b/api/overview/azure/legacy/microsoft.opentelemetry.exporter.azuremonitor-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/10/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Monitor Exporter client library for .NET - version 1.0.0-beta.1 
 

--- a/api/overview/azure/preview/ai.metricsadvisor-readme.md
+++ b/api/overview/azure/preview/ai.metricsadvisor-readme.md
@@ -5,8 +5,6 @@ ms.date: 06/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: metricsadvisor
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Metrics Advisor client library for .NET - version 1.0.0-beta.4 
 

--- a/api/overview/azure/preview/ai.personalizer-readme.md
+++ b/api/overview/azure/preview/ai.personalizer-readme.md
@@ -5,8 +5,6 @@ ms.date: 03/23/2022
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: personalizer
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Personalizer client library for .NET - version 2.0.0-beta.2 
 

--- a/api/overview/azure/preview/analytics.purview.account-readme.md
+++ b/api/overview/azure/preview/analytics.purview.account-readme.md
@@ -5,8 +5,6 @@ ms.date: 08/25/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Purview Account client library for .NET - version 1.0.0-beta.1 
 

--- a/api/overview/azure/preview/analytics.purview.administration-readme.md
+++ b/api/overview/azure/preview/analytics.purview.administration-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/19/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: purview
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Purview Administration client library for .NET - version 1.0.0-beta.1 
 

--- a/api/overview/azure/preview/analytics.purview.scanning-readme.md
+++ b/api/overview/azure/preview/analytics.purview.scanning-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/15/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: purview
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Purview Scanning client library for .NET - version 1.0.0-beta.2 
 

--- a/api/overview/azure/preview/analytics.synapse.accesscontrol-readme.md
+++ b/api/overview/azure/preview/analytics.synapse.accesscontrol-readme.md
@@ -5,8 +5,6 @@ ms.date: 08/13/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: synapseanalytics
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Synapse Analytics Access Control client library for .NET - version 1.0.0-preview.5 
 

--- a/api/overview/azure/preview/analytics.synapse.managedprivateendpoints-readme.md
+++ b/api/overview/azure/preview/analytics.synapse.managedprivateendpoints-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: synapseanalytics
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Synapse Analytics Managed Private Endpoints client library for .NET - version 1.0.0-beta.5 
 

--- a/api/overview/azure/preview/analytics.synapse.monitoring-readme.md
+++ b/api/overview/azure/preview/analytics.synapse.monitoring-readme.md
@@ -5,8 +5,6 @@ ms.date: 05/11/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: synapseanalytics
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Synapse Analytics Monitoring client library for .NET - version 1.0.0-beta.3 
 

--- a/api/overview/azure/preview/analytics.synapse.spark-readme.md
+++ b/api/overview/azure/preview/analytics.synapse.spark-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/05/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: synapseanalytics
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Synapse Spark client library for .NET - version 1.0.0-preview.8 
 

--- a/api/overview/azure/preview/app-auth-migration.md
+++ b/api/overview/azure/preview/app-auth-migration.md
@@ -5,7 +5,6 @@ keywords: Azure, .net, SDK, API, Azure.Identity, identity
 ms.date: 10/27/2020
 ms.topic: reference
 ms.devlang: .net
-ms.prod: azure
 ---
 # AppAuthentication to Azure.Identity Migration Guidance
 

--- a/api/overview/azure/preview/communication.administration-readme.md
+++ b/api/overview/azure/preview/communication.administration-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/16/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: communication
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Communication Administration client library for .NET - version 1.0.0-beta.3 
 

--- a/api/overview/azure/preview/communication.callingserver-readme.md
+++ b/api/overview/azure/preview/communication.callingserver-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/05/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: communication
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Communication CallingServer client library for .NET - version 1.0.0-beta.3 
 

--- a/api/overview/azure/preview/core.amqp-readme.md
+++ b/api/overview/azure/preview/core.amqp-readme.md
@@ -5,8 +5,6 @@ ms.date: 04/06/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Core AMQP shared client library for .NET - version 1.1.0-beta.1 
 

--- a/api/overview/azure/preview/iot.timeseriesinsights-readme.md
+++ b/api/overview/azure/preview/iot.timeseriesinsights-readme.md
@@ -5,8 +5,6 @@ ms.date: 05/27/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure IoT Time Series Insights client library for .NET - version 1.0.0-beta.1 
 

--- a/api/overview/azure/preview/media.analytics.edge-readme.md
+++ b/api/overview/azure/preview/media.analytics.edge-readme.md
@@ -5,8 +5,6 @@ ms.date: 01/13/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Live Video Analytics for IoT Edge client library for .NET - version 1.0.0-beta.1 
 

--- a/api/overview/azure/preview/microsoft.azure.core.spatial-readme.md
+++ b/api/overview/azure/preview/microsoft.azure.core.spatial-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/13/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # System.Text.Json support for Microsoft.Spatial library for .NET (Preview)
 

--- a/api/overview/azure/preview/microsoft.azure.core.spatial.newtonsoftjson-readme.md
+++ b/api/overview/azure/preview/microsoft.azure.core.spatial.newtonsoftjson-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/13/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: core
-ms.technology: azure
-ms.prod: azure
 ---
 # Newtonsoft.Json support for Microsoft.Spatial library for .NET (Preview)
 

--- a/api/overview/azure/preview/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme.md
+++ b/api/overview/azure/preview/microsoft.azure.messaging.eventgrid.cloudnativecloudevents-readme.md
@@ -5,8 +5,6 @@ ms.date: 06/15/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # CloudNative CloudEvent support for Azure.Messaging.EventGrid library for .NET (Preview)
 

--- a/api/overview/azure/preview/microsoft.azure.webjobs.extensions.eventhubs-readme.md
+++ b/api/overview/azure/preview/microsoft.azure.webjobs.extensions.eventhubs-readme.md
@@ -5,8 +5,6 @@ ms.date: 07/09/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: webjobs
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure WebJobs Event Hubs client library for .NET - version 5.0.0-beta.7 
 

--- a/api/overview/azure/preview/microsoft.azure.webjobs.extensions.servicebus-readme.md
+++ b/api/overview/azure/preview/microsoft.azure.webjobs.extensions.servicebus-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/08/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: webjobs
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure WebJobs Service Bus client library for .NET - version 5.0.0-beta.6 
 

--- a/api/overview/azure/preview/microsoft.core.newtonsoftjson-readme.md
+++ b/api/overview/azure/preview/microsoft.core.newtonsoftjson-readme.md
@@ -5,8 +5,6 @@ ms.date: 08/07/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Newtonsoft.Json implementation for Azure Core Experimental shared client library for .NET - version 1.0.0-preview.1 
 

--- a/api/overview/azure/preview/microsoft.core.spatial-readme.md
+++ b/api/overview/azure/preview/microsoft.core.spatial-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/09/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # System.Text.Json support for Microsoft.Spatial library for .NET (Preview)
 

--- a/api/overview/azure/preview/microsoft.core.spatial.newtonsoftjson-readme.md
+++ b/api/overview/azure/preview/microsoft.core.spatial.newtonsoftjson-readme.md
@@ -5,8 +5,6 @@ ms.date: 10/09/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Newtonsoft.Json support for Microsoft.Azure.Core.Spatial library for .NET
 

--- a/api/overview/azure/preview/microsoft.data.schemaregistry.apacheavro-readme.md
+++ b/api/overview/azure/preview/microsoft.data.schemaregistry.apacheavro-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/09/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Schema Registry Apache Avro client library for .NET - version 1.0.0-beta.1 
 

--- a/api/overview/azure/preview/microsoft.extensions.azure-readme.md
+++ b/api/overview/azure/preview/microsoft.extensions.azure-readme.md
@@ -5,8 +5,6 @@ ms.date: 05/11/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: extensions
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure client library integration for ASP.NET Core (Preview)
 

--- a/api/overview/azure/preview/microsoft.webjobs.extensions.storage-readme.md
+++ b/api/overview/azure/preview/microsoft.webjobs.extensions.storage-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: webjobsextensions
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure WebJobs Storage Blobs and Queues client library for .NET - version 5.0.0-beta.1 
 

--- a/api/overview/azure/preview/microsoft.webjobs.extensions.storage.blobs-readme.md
+++ b/api/overview/azure/preview/microsoft.webjobs.extensions.storage.blobs-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure WebJobs Storage Blobs client library for .NET - version 5.0.0-beta.1 
 

--- a/api/overview/azure/preview/microsoft.webjobs.extensions.storage.queues-readme.md
+++ b/api/overview/azure/preview/microsoft.webjobs.extensions.storage.queues-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure WebJobs Storage Queues client library for .NET - version 5.0.0-beta.1 
 

--- a/api/overview/azure/preview/mixedreality.authentication-readme.md
+++ b/api/overview/azure/preview/mixedreality.authentication-readme.md
@@ -5,8 +5,6 @@ ms.date: 02/16/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: mixedreality
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Mixed Reality Authentication client library for .NET - version 1.0.0-beta.2 
 

--- a/api/overview/azure/preview/mixedreality.remoterendering-readme.md
+++ b/api/overview/azure/preview/mixedreality.remoterendering-readme.md
@@ -5,8 +5,6 @@ ms.date: 02/24/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: mixedreality
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Remote Rendering client library for .NET - version 1.0.0-beta.3 
 

--- a/api/overview/azure/preview/quantum.jobs-readme.md
+++ b/api/overview/azure/preview/quantum.jobs-readme.md
@@ -5,8 +5,6 @@ ms.date: 01/19/2022
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: quantum
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Quantum Jobs client library for .NET - version 1.0.0-beta.3 
 

--- a/api/overview/azure/preview/resourcemanager.extendedlocation-readme.md
+++ b/api/overview/azure/preview/resourcemanager.extendedlocation-readme.md
@@ -5,8 +5,6 @@ ms.date: 04/08/2022
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: extendedlocation
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure ExtendedLocation Management client library for .NET - version 1.0.0-beta.2 
 

--- a/api/overview/azure/preview/resourcemanager.insights-readme.md
+++ b/api/overview/azure/preview/resourcemanager.insights-readme.md
@@ -5,8 +5,6 @@ ms.date: 09/28/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Insights Management client library for .NET - version 1.0.0-preview.1 
 

--- a/api/overview/azure/preview/security.attestation-readme.md
+++ b/api/overview/azure/preview/security.attestation-readme.md
@@ -5,8 +5,6 @@ ms.date: 04/05/2021
 ms.topic: reference
 ms.devlang: dotnet
 ms.service: attestation
-ms.technology: azure
-ms.prod: azure
 ---
 # Azure Attestation client library for .NET - version 1.0.0-beta.2 
 

--- a/api/overview/azure/preview/service-to-service-authentication.md
+++ b/api/overview/azure/preview/service-to-service-authentication.md
@@ -5,7 +5,6 @@ keywords: Azure, .net, SDK, API, Azure.Identity, identity
 ms.date: 10/27/2020
 ms.topic: reference
 ms.devlang: .net
-ms.prod: azure
 ---
 # App Authentication client library for .NET - version 1.6.0
 

--- a/api/overview/azure/preview/system.memory.data-readme.md
+++ b/api/overview/azure/preview/system.memory.data-readme.md
@@ -5,8 +5,6 @@ ms.date: 11/04/2020
 ms.topic: reference
 ms.devlang: .net
 ms.service: 
-ms.technology: azure
-ms.prod: azure
 ---
 #  System.Memory.Data library for .NET (Preview) 
 

--- a/index.md
+++ b/index.md
@@ -6,8 +6,6 @@ author: rloutlaw
 ms.author: routlaw
 ms.date: 04/14/2021
 ms.topic: managed-reference
-ms.prod: azure
-ms.technology: azure
 ms.devlang: dotnet
 ms.assetid: 46ad4ac6-bc51-45c9-b6dd-394ed0af5424
 ---


### PR DESCRIPTION
These files are updated by automation, but that automation no longer attempts to include ms.prod and ms.technology metadata - they only persist because they're already on the files and the automation preserves them.