### PR TITLE
Update metadata for Azure App Configuration external packages.

### DIFF
--- a/metadata/latest/Microsoft.Azure.AppConfiguration.AspNetCore.json
+++ b/metadata/latest/Microsoft.Azure.AppConfiguration.AspNetCore.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.AppConfiguration.AspNetCore",
-  "Version": "8.2.0",
+  "Version": "8.4.0",
   "Namespaces": [
     "Microsoft.AspNetCore.Builder"
   ],

--- a/metadata/latest/Microsoft.Azure.AppConfiguration.Functions.Worker.json
+++ b/metadata/latest/Microsoft.Azure.AppConfiguration.Functions.Worker.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.AppConfiguration.Functions.Worker",
-  "Version": "8.2.0",
+  "Version": "8.4.0",
   "Namespaces": [
     "Microsoft.Extensions.Hosting"
   ],

--- a/metadata/latest/Microsoft.Extensions.Configuration.AzureAppConfiguration.json
+++ b/metadata/latest/Microsoft.Extensions.Configuration.AzureAppConfiguration.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Extensions.Configuration.AzureAppConfiguration",
-  "Version": "8.2.0",
+  "Version": "8.4.0",
   "Namespaces": [
     "Microsoft.Extensions.Configuration",
     "Microsoft.Extensions.Configuration.AzureAppConfiguration",

--- a/metadata/latest/Microsoft.FeatureManagement.AspNetCore.json
+++ b/metadata/latest/Microsoft.FeatureManagement.AspNetCore.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.FeatureManagement.AspNetCore",
-  "Version": "2.5.1",
+  "Version": "4.3.0",
   "DocsCiConfigProperties": {
     "isPrerelease": "true"
   },

--- a/metadata/latest/Microsoft.FeatureManagement.json
+++ b/metadata/latest/Microsoft.FeatureManagement.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.FeatureManagement",
-  "Version": "3.0.0",
+  "Version": "4.3.0",
   "DocsCiConfigProperties": {
     "isPrerelease": "true"
   },

--- a/metadata/preview/Microsoft.Azure.AppConfiguration.AspNetCore.json
+++ b/metadata/preview/Microsoft.Azure.AppConfiguration.AspNetCore.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.AppConfiguration.AspNetCore",
-  "Version": "8.0.0-preview.3",
+  "Version": "8.5.0-preview",
   "Namespaces": [
     "Microsoft.AspNetCore.Builder"
   ],

--- a/metadata/preview/Microsoft.Azure.AppConfiguration.Functions.Worker.json
+++ b/metadata/preview/Microsoft.Azure.AppConfiguration.Functions.Worker.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.AppConfiguration.Functions.Worker",
-  "Version": "8.0.0-preview.3",
+  "Version": "8.5.0-preview",
   "Namespaces": [
     "Microsoft.Extensions.Hosting"
   ],

--- a/metadata/preview/Microsoft.Extensions.Configuration.AzureAppConfiguration.json
+++ b/metadata/preview/Microsoft.Extensions.Configuration.AzureAppConfiguration.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Extensions.Configuration.AzureAppConfiguration",
-  "Version": "8.0.0-preview.3",
+  "Version": "8.5.0-preview",
   "Namespaces": [
     "Microsoft.Extensions.Configuration",
     "Microsoft.Extensions.Configuration.AzureAppConfiguration",

--- a/metadata/preview/Microsoft.FeatureManagement.AspNetCore.json
+++ b/metadata/preview/Microsoft.FeatureManagement.AspNetCore.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.FeatureManagement.AspNetCore",
-  "Version": "3.0.0-preview",
+  "Version": "4.0.0-preview5",
   "DocsCiConfigProperties": {
     "isPrerelease": "true"
   },

--- a/metadata/preview/Microsoft.FeatureManagement.json
+++ b/metadata/preview/Microsoft.FeatureManagement.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.FeatureManagement",
-  "Version": "2.6.0-preview2",
+  "Version": "4.0.0-preview5",
   "DocsCiConfigProperties": {
     "isPrerelease": "true"
   },


### PR DESCRIPTION
Azure App Configuration packages require a manual update since they are released externally. This update encompasses the .NET packages advertised by [Azure App Configuration](https://github.com/Azure/AppConfiguration#client-libraries).