### PR TITLE
Update Speech SDK metadata for 1.48.1 release (.NET)

### DIFF
--- a/metadata/latest/Microsoft.CognitiveServices.Speech.Remoteconversation.json
+++ b/metadata/latest/Microsoft.CognitiveServices.Speech.Remoteconversation.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.CognitiveServices.Speech.Remoteconversation",
-  "Version": "1.47.0",
+  "Version": "1.48.1",
   "Namespaces": "Microsoft.CognitiveServices.Speech.RemoteMeeting",
   "DocsCiConfigProperties": {},
   "MSDocService": "placeholder",

--- a/metadata/latest/Microsoft.CognitiveServices.Speech.json
+++ b/metadata/latest/Microsoft.CognitiveServices.Speech.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.CognitiveServices.Speech",
-  "Version": "1.47.0",
+  "Version": "1.48.1",
   "Namespaces": [
     "Azure.AI.Vision.Common.Internal",
     "Microsoft.CognitiveServices.Speech",


### PR DESCRIPTION
This PR updates the Speech SDK package metadata for the 1.48.1 release.

## Changes
- Updated `Microsoft.CognitiveServices.Speech.json` version to 1.48.1
- Updated `Microsoft.CognitiveServices.Speech.Remoteconversation.json` version to 1.48.1


## Validation
- [ ] Version numbers are correct
- [ ] JSON files are valid