### PR TITLE
Update Microsoft.Azure.Cosmos.json to 3.60.0

### DIFF
--- a/metadata/latest/Microsoft.Azure.Cosmos.json
+++ b/metadata/latest/Microsoft.Azure.Cosmos.json
@@ -1,6 +1,6 @@
 {
   "Name": "Microsoft.Azure.Cosmos",
-  "Version": "3.58.0",
+  "Version": "3.60.0",
   "Namespaces": [
     "Microsoft.Azure.Cosmos",
     "Microsoft.Azure.Cosmos.Fluent",
@@ -10,7 +10,7 @@
   ],
   "DocsCiConfigProperties": {},
   "MSDocService": "placeholder",
-  "ServiceDirectory": "https://github.com/Azure/azure-cosmos-dotnet-v3/tree/3.58.0/Microsoft.Azure.Cosmos",
+  "ServiceDirectory": "https://github.com/Azure/azure-cosmos-dotnet-v3/tree/3.60.0/Microsoft.Azure.Cosmos",
   "SdkType": "client",
   "IsNewSdk": false,
   "DirectoryPath": ""


### PR DESCRIPTION
Updates `Microsoft.Azure.Cosmos` metadata to reflect the latest GA release `3.60.0`.

- Version: 3.58.0 → 3.60.0
- ServiceDirectory tree link updated

NuGet: https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.60.0
Release PR: https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5876